### PR TITLE
Improve error reporting

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -41,7 +41,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     in
     Store.build t.store ~base ~id ~log:stdout (fun result_tmp ->
         let argv = shell @ [cmd] in
-        let config = Sandbox.Config.v ~cwd:workdir ~argv ~hostname ~user ~env in
+        let config = Config.v ~cwd:workdir ~argv ~hostname ~user ~env in
         Os.with_pipe_to_child @@ fun ~r:stdin ~w:close_me ->
         Lwt_unix.close close_me >>= fun () ->
         Sandbox.run ~stdin t.sandbox config result_tmp
@@ -70,7 +70,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     let id = Digest.to_hex (Digest.string (show_copy_details details)) in
     Store.build t.store ~base ~id ~log:stdout (fun result_tmp ->
         let argv = ["tar"; "-xf"; "-"] in
-        let config = Sandbox.Config.v ~cwd:"/" ~argv ~hostname ~user ~env:["PATH", "/bin:/usr/bin"] in
+        let config = Config.v ~cwd:"/" ~argv ~hostname ~user ~env:["PATH", "/bin:/usr/bin"] in
         Os.with_pipe_to_child @@ fun ~r:from_us ~w:to_untar ->
         let proc = Sandbox.run ~stdin:from_us t.sandbox config result_tmp in
         let send =

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -27,5 +27,5 @@ module Make (Store : S.STORE) (Sandbox : S.SANDBOX) : sig
     t ->
     Context.t ->
     Spec.stage ->
-    (S.id, [> ]) Lwt_result.t
+    (S.id, Sandbox.error) Lwt_result.t
 end

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -1,0 +1,10 @@
+type t = {
+  cwd : string;
+  argv : string list;
+  hostname : string;
+  user : Spec.user;
+  env : Os.env;
+}
+
+let v ~cwd ~argv ~hostname ~user ~env =
+  { cwd; argv; hostname; user; env }

--- a/lib/obuilder.ml
+++ b/lib/obuilder.ml
@@ -1,5 +1,6 @@
 module S = S
 module Spec = Spec
+module Config = Config
 module Context = Build.Context
 module Builder = Build.Make
 

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -27,19 +27,11 @@ end
 module type SANDBOX = sig
   type t
 
-  module Config : sig
-    type t
+  type error = private [> ]
 
-    val v :
-      cwd:string ->
-      argv:string list ->
-      hostname:string ->
-      user:Spec.user ->
-      env:Os.env ->
-      t
-  end
+  val pp_error : error Fmt.t
 
-  val run : ?stdin:Os.unix_fd -> t -> Config.t -> string -> (unit, 'a) Lwt_result.t
+  val run : ?stdin:Os.unix_fd -> t -> Config.t -> string -> (unit, error) Lwt_result.t
   (** [run t config dir] runs the operation [config] in a sandbox with root
       filesystem [rootfs]. *)
 end

--- a/main.ml
+++ b/main.ml
@@ -25,7 +25,9 @@ let build_in (type s) (module Store : Obuilder.S.STORE with type t = s) (store :
   | Ok x ->
     Fmt.pr "Got: %S@." (x :> string);
     Lwt.return_unit
-  | Error `Cant_happen -> assert false
+  | Error e ->
+    Fmt.epr "Build step failed: %a@." Sandbox.pp_error e;
+    exit 1
 
 let build store spec src_dir =
   Lwt_main.run @@ begin

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -1,30 +1,21 @@
-open Lwt.Infix
+type error = [`Exn of exn]
 
-module Config = struct
-  type t = {
-    cwd : string;
-    argv : string list;
-    hostname : string;
-    user : Obuilder.Spec.user;
-    env : Obuilder.Os.env;
-  }
-
-  let v ~cwd ~argv ~hostname ~user ~env =
-    { cwd; argv; hostname; user; env }
-end
+let pp_error f (`Exn ex) = Fmt.exn f ex
 
 type t = {
   dir : string;
-  expect : (?stdin:Obuilder.Os.unix_fd -> Config.t -> string -> unit Lwt.t) Queue.t;
+  expect : (?stdin:Obuilder.Os.unix_fd -> Obuilder.Config.t -> string -> unit Lwt.t) Queue.t;
 }
 
 let expect t x = Queue.add x t.expect
 
-let run ?stdin t (config:Config.t) dir =
+let run ?stdin t (config:Obuilder.Config.t) dir =
   match Queue.take_opt t.expect with
   | None -> Fmt.failwith "Unexpected sandbox execution: %a" Fmt.(Dump.list string) config.argv
   | Some fn ->
-    fn ?stdin config dir >|= fun () ->
-    Ok ()
+    Lwt.try_bind
+      (fun () -> fn ?stdin config dir)
+      Lwt_result.return
+      (fun ex -> Lwt_result.fail (`Exn ex))
 
 let create dir = { dir; expect = Queue.create () }

--- a/test/mock_sandbox.mli
+++ b/test/mock_sandbox.mli
@@ -1,0 +1,5 @@
+include Obuilder.S.SANDBOX with
+  type error = [`Exn of exn]
+
+val create : string -> t
+val expect : t -> (?stdin:Obuilder.Os.unix_fd -> Obuilder.Config.t -> string -> unit Lwt.t) -> unit

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,7 +29,7 @@ let test_simple _switch () =
       Lwt_io.(with_file ~mode:output) (rootfs / "appended") (fun ch -> Lwt_io.write ch (orig ^ "runner"))
     );
   Builder.build builder context spec >>= function
-  | Error `Cant_happen -> assert false
+  | Error (`Exn ex) -> raise ex
   | Ok id ->
     let result = Mock_store.path store id in
     Lwt_io.(with_file ~mode:input) (result / "rootfs" / "appended") Lwt_io.read >>= fun text ->


### PR DESCRIPTION
When a command run by `runc` fails, report the error as coming from that command, not from `runc`.