### PR TITLE
Combine parallel builds for the same key

### DIFF
--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -43,7 +43,7 @@ let build t ?base ~id ~log fn =
         if Sys.file_exists log_file then Unix.unlink log_file
     end
     >>= fun () ->
-    fn result_tmp >>!= fun () ->
+    Build_log.with_log (result_tmp / "log") (fun log -> fn ~log result_tmp) >>!= fun () ->
     (* delete_snapshot_if_exists result >>= fun () -> *) (* XXX: just for testing *)
     Os.exec ["btrfs"; "subvolume"; "snapshot"; "-r"; result_tmp; result] >>= fun () ->
     Os.exec ["sudo"; "btrfs"; "subvolume"; "delete"; result_tmp] >>= fun () ->

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -8,13 +8,15 @@ module Context : sig
     ?user:Spec.user ->
     ?workdir:string ->
     ?shell:string list ->
+    log:S.logger ->
     src_dir:string ->
     unit -> t
-    (** [context ~src_dir] is a build context where copy operations read from the (host) directory [src_dir].
+    (** [context ~log ~src_dir] is a build context where copy operations read from the (host) directory [src_dir].
         @param env Environment in which to run commands.
         @param user Container user to run as.
         @param workdir Directory in the container namespace for cwd.
         @param shell The command used to run shell commands (default [["/bin/bash"; "-c"]]).
+        @param log Function to receive log data.
     *)
 end
 
@@ -27,5 +29,5 @@ module Make (Store : S.STORE) (Sandbox : S.SANDBOX) : sig
     t ->
     Context.t ->
     Spec.stage ->
-    (S.id, Sandbox.error) Lwt_result.t
+    (S.id, [`Msg of string]) Lwt_result.t
 end

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -1,16 +1,95 @@
+open Lwt.Infix
+
+let max_chunk_size = 4096
+
 type t = {
-  to_file : out_channel;
+  mutable state : [
+    | `Open of Lwt_unix.file_descr * unit Lwt_condition.t  (* Fires after writing more data. *)
+    | `Readonly of string
+    | `Empty
+    | `Finished
+  ];
+  mutable len : int;
 }
 
-let with_log path fn =
-  let to_file = open_out path in
-  let t = { to_file } in
+let with_dup fd fn =
+  let fd = Lwt_unix.dup fd in
   Lwt.finalize
-    (fun () -> fn t)
-    (fun () -> close_out to_file; Lwt.return_unit)
+    (fun () -> fn fd)
+    (fun () -> Lwt_unix.close fd)
 
-let write t buf ofs len =
-  output t.to_file buf ofs len;
-  output stdout buf ofs len;
-  flush stdout;
-  Lwt.return_unit
+let tail t dst =
+  match t.state with
+  | `Finished -> invalid_arg "tail: log is finished!"
+  | `Readonly path ->
+    Lwt_io.(with_file ~mode:input) path @@ fun ch ->
+    let buf = Bytes.create max_chunk_size in
+    let rec aux () =
+      Lwt_io.read_into ch buf 0 max_chunk_size >>= function
+      | 0 -> Lwt.return_unit
+      | n -> dst (Bytes.sub_string buf 0 n); aux ()
+    in
+    aux ()
+  | `Empty -> Lwt.return_unit
+  | `Open (fd, cond) ->
+    (* Dup [fd], which can still work after [fd] is closed. *)
+    with_dup fd @@ fun fd ->
+    let buf = Bytes.create max_chunk_size in
+    let rec aux i =
+      let avail = min (t.len - i) max_chunk_size in
+      if avail > 0 then (
+        Lwt_unix.pread fd ~file_offset:i buf 0 avail >>= fun n ->
+        dst (Bytes.sub_string buf 0 n);
+        aux (i + avail)
+      ) else (
+        match t.state with
+        | `Open _ -> Lwt_condition.wait cond >>= fun () -> aux i
+        | _ -> Lwt.return_unit
+      )
+    in
+    aux 0
+
+let create path =
+  Lwt_unix.openfile path Lwt_unix.[O_CREAT; O_TRUNC; O_RDWR] 0o666 >|= fun fd ->
+  let cond = Lwt_condition.create () in
+  {
+    state = `Open (fd, cond);
+    len = 0;
+  }
+
+let finish t =
+  match t.state with
+  | `Finished -> invalid_arg "Log is already finished!"
+  | `Open (fd, cond) ->
+    t.state <- `Finished;
+    Lwt_unix.close fd >|= fun () ->
+    Lwt_condition.broadcast cond ()
+  | `Readonly _ | `Empty ->
+    t.state <- `Finished;
+    Lwt.return_unit
+
+let write t data =
+  match t.state with
+  | `Finished -> invalid_arg "write: log is finished!"
+  | `Readonly _ | `Empty -> invalid_arg "Log is read-only!"
+  | `Open (fd, cond) ->
+    let len = String.length data in
+    Os.write_all fd (Bytes.of_string data) 0 len >>= fun () ->
+    t.len <- t.len + len;
+    Lwt_condition.broadcast cond ();
+    Lwt.return_unit
+
+let of_saved path =
+  Lwt_unix.lstat path >|= fun stat ->
+  {
+    state = `Readonly path;
+    len = stat.st_size;
+  }
+
+let printf t fmt =
+  Fmt.kstrf (write t) fmt
+
+let empty = {
+  state = `Empty;
+  len = 0;
+}

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -1,0 +1,16 @@
+type t = {
+  to_file : out_channel;
+}
+
+let with_log path fn =
+  let to_file = open_out path in
+  let t = { to_file } in
+  Lwt.finalize
+    (fun () -> fn t)
+    (fun () -> close_out to_file; Lwt.return_unit)
+
+let write t buf ofs len =
+  output t.to_file buf ofs len;
+  output stdout buf ofs len;
+  flush stdout;
+  Lwt.return_unit

--- a/lib/build_log.mli
+++ b/lib/build_log.mli
@@ -1,0 +1,32 @@
+type t
+(** The log for a single build step. *)
+
+(** {2 Creating logs} *)
+
+val create : string -> t Lwt.t
+(** [create path] creates a new log file at temporary location [path].
+    Call [finish] when done to release the file descriptor. *)
+
+val finish : t -> unit Lwt.t
+(** [finish t] marks log [t] as finished.
+    If it was open for writing, this closes the file descriptor.
+    It cannot be used after this (for reading or writing), although existing
+    background operations (e.g. [tail]) can continue successfully. *)
+
+val write : t -> string -> unit Lwt.t
+(** [write t data] appends [data] to the log. *)
+
+val printf : t -> ('a, Format.formatter, unit, unit Lwt.t) format4 -> 'a
+(** [printf t fmt] is a wrapper for [write t] that takes a format string. *)
+
+(** {2 Reading logs} *)
+
+val empty : t
+(** [empty] is a read-only log with no content. *)
+
+val of_saved : string -> t Lwt.t
+(** [of_saved path] is a read-only log which reads from [path]. *)
+
+val tail : t -> (string -> unit) -> unit Lwt.t
+(** [tail t dst] streams data from the log to [dst].
+    This can be called at any time in the lifecycle of the log. *)

--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -10,9 +10,9 @@ module Make (Raw : S.STORE) = struct
 
   let build t ?base ~id ~log fn =
     let build_needed = ref false in
-    Raw.build t.raw ?base ~id ~log (fun dir ->
+    Raw.build t.raw ?base ~id ~log (fun ~log dir ->
         build_needed := true;
-        fn dir
+        fn ~log dir
       )
     >|= function
     | Error _ as e -> e

--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -1,6 +1,5 @@
-open Lwt.Infix
-
 let ( / ) = Filename.concat
+let ( >>!= ) = Lwt_result.bind
 
 module Make (Raw : S.STORE) = struct
   type t = {
@@ -9,20 +8,23 @@ module Make (Raw : S.STORE) = struct
   }
 
   let build t ?base ~id ~log fn =
-    let build_needed = ref false in
-    Raw.build t.raw ?base ~id ~log (fun ~log dir ->
-        build_needed := true;
-        fn ~log dir
-      )
-    >|= function
-    | Error _ as e -> e
-    | Ok _ as r ->
+    match Raw.result t.raw id with
+    | Some dir ->
+      let now = Unix.(gmtime (gettimeofday ())) in
+      Dao.set_used t.dao ~id ~now;
+      let log_file = dir / "log" in
+      if Sys.file_exists log_file then Os.cat_file log_file ~dst:log;
+      Lwt_result.return ()
+    | None ->
+      Raw.build t.raw ?base ~id (fun dir ->
+          let log_file = dir / "log" in
+          if Sys.file_exists log_file then Unix.unlink log_file;
+          Build_log.with_log log_file (fun log -> fn ~log dir)
+        )
+      >>!= fun () ->
       let now = Unix.(gmtime (gettimeofday () )) in
-      if !build_needed then
-        Dao.add t.dao ?parent:(base :> string option) ~id ~now
-      else
-        Dao.set_used t.dao ~id ~now;
-      r
+      Dao.add t.dao ?parent:(base :> string option) ~id ~now;
+      Lwt_result.return ()
 
   let wrap raw =
     let db_dir = Raw.state_dir raw / "db" in
@@ -30,6 +32,4 @@ module Make (Raw : S.STORE) = struct
     let db = Db.of_dir (db_dir / "db.sqlite") in
     let dao = Dao.create db in
     { raw; dao }
-
-  let state_dir t = Raw.state_dir t.raw
 end

--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -1,35 +1,100 @@
+open Lwt.Infix
+
 let ( / ) = Filename.concat
-let ( >>!= ) = Lwt_result.bind
 
 module Make (Raw : S.STORE) = struct
+  type build = {
+    log : Build_log.t Lwt.t;
+    result : (S.id, [`Msg of string]) Lwt_result.t;
+  }
+
+  module Builds = Map.Make(String)
+
   type t = {
     raw : Raw.t;
     dao : Dao.t;
+    mutable in_progress : build Builds.t;
   }
 
+  let finish_log ~tail_log ~set_log log =
+    match Lwt.state log with
+    | Lwt.Return log ->
+      Build_log.finish log >>= fun () ->
+      tail_log
+    | Lwt.Fail _ ->
+      Lwt.return_unit
+    | Lwt.Sleep ->
+      Lwt.wakeup_exn set_log (Failure "Build ended without setting a log!");
+      Lwt.return_unit
+
+  (* Check to see if we're in the process of building [id].
+     If so, just tail the log from that.
+     If not, call [fn set_log] to start a new build.
+     [fn] should set the log being used as soon as it knows it
+     (this can't happen until we've created the temporary directory
+     in the underlying store). *)
+  let share_build t ~log:client_log id fn =
+    match Builds.find_opt id t.in_progress with
+    | Some { log; result } ->
+      log >>= fun log ->
+      Build_log.tail log (client_log `Output) >>= fun () ->
+      result
+    | None ->
+      let result, set_result = Lwt.wait () in
+      let log, set_log = Lwt.wait () in
+      let tail_log = log >>= fun log -> Build_log.tail log (client_log `Output) in
+      t.in_progress <- Builds.add id { log; result } t.in_progress;
+      Lwt.async
+        (fun () ->
+           Lwt.try_bind
+             (fun () -> fn set_log)
+             (fun r ->
+                t.in_progress <- Builds.remove id t.in_progress;
+                Lwt.wakeup_later set_result r;
+                finish_log ~tail_log ~set_log log
+             )
+             (fun ex ->
+                t.in_progress <- Builds.remove id t.in_progress;
+                Lwt.wakeup_later_exn set_result ex;
+                finish_log ~tail_log ~set_log log
+             )
+        );
+      result
+
   let build t ?base ~id ~log fn =
+    share_build t id ~log @@ fun set_log ->
     match Raw.result t.raw id with
     | Some dir ->
+      log `Note (Fmt.strf "---> using cached result %S" dir);
       let now = Unix.(gmtime (gettimeofday ())) in
       Dao.set_used t.dao ~id ~now;
       let log_file = dir / "log" in
-      if Sys.file_exists log_file then Os.cat_file log_file ~dst:log;
-      Lwt_result.return ()
+      begin
+        if Sys.file_exists log_file then Build_log.of_saved log_file
+        else Lwt.return (Build_log.empty)
+      end >>= fun log ->
+      Lwt.wakeup set_log log;
+      Lwt_result.return id
     | None ->
       Raw.build t.raw ?base ~id (fun dir ->
           let log_file = dir / "log" in
           if Sys.file_exists log_file then Unix.unlink log_file;
-          Build_log.with_log log_file (fun log -> fn ~log dir)
+          Build_log.create log_file >>= fun log ->
+          Lwt.wakeup set_log log;
+          fn ~log dir
         )
-      >>!= fun () ->
-      let now = Unix.(gmtime (gettimeofday () )) in
-      Dao.add t.dao ?parent:(base :> string option) ~id ~now;
-      Lwt_result.return ()
+      >>= function
+      | Ok () ->
+        let now = Unix.(gmtime (gettimeofday () )) in
+        Dao.add t.dao ?parent:(base :> string option) ~id ~now;
+        Lwt_result.return id
+      | Error _ as e ->
+        Lwt.return e
 
   let wrap raw =
     let db_dir = Raw.state_dir raw / "db" in
     Os.ensure_dir db_dir;
     let db = Db.of_dir (db_dir / "db.sqlite") in
     let dao = Dao.create db in
-    { raw; dao }
+    { raw; dao; in_progress = Builds.empty }
 end

--- a/lib/db_store.mli
+++ b/lib/db_store.mli
@@ -4,9 +4,9 @@ module Make (Raw : S.STORE) : sig
   val build :
     t -> ?base:S.id ->
     id:S.id ->
-    log:out_channel ->
-    (log:Build_log.t -> string -> (unit, 'e) Lwt_result.t) ->
-    (unit, 'e) Lwt_result.t
+    log:S.logger ->
+    (log:Build_log.t -> string -> (unit, [`Msg of string]) Lwt_result.t) ->
+    (S.id, [`Msg of string]) Lwt_result.t
 
   val wrap : Raw.t -> t
 end

--- a/lib/db_store.mli
+++ b/lib/db_store.mli
@@ -1,5 +1,12 @@
 module Make (Raw : S.STORE) : sig
-  include S.STORE
+  type t
+
+  val build :
+    t -> ?base:S.id ->
+    id:S.id ->
+    log:out_channel ->
+    (log:Build_log.t -> string -> (unit, 'e) Lwt_result.t) ->
+    (unit, 'e) Lwt_result.t
 
   val wrap : Raw.t -> t
 end

--- a/lib/obuilder.ml
+++ b/lib/obuilder.ml
@@ -3,9 +3,11 @@ module Spec = Spec
 module Config = Config
 module Context = Build.Context
 module Builder = Build.Make
+module Build_log = Build_log
 
 module Btrfs_store = Btrfs_store
 module Zfs_store = Zfs_store
+
 module Db = Db
 module Os = Os
 

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -41,18 +41,6 @@ let rec write_all fd buf ofs len =
     write_all fd buf (ofs + n) (len - n)
   )
 
-let tee ~src ~dst =
-  let buf = Bytes.create 4096 in
-  let rec aux () =
-    Lwt_unix.read src buf 0 (Bytes.length buf) >>= function
-    | 0 -> Lwt.return_unit
-    | n ->
-      output stdout buf 0 n;
-      flush stdout;
-      write_all dst buf 0 n >>= aux
-  in
-  aux ()
-
 let cat_file path ~dst =
   let ch = open_in path in
   Fun.protect ~finally:(fun () -> close_in ch)

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -41,20 +41,6 @@ let rec write_all fd buf ofs len =
     write_all fd buf (ofs + n) (len - n)
   )
 
-let cat_file path ~dst =
-  let ch = open_in path in
-  Fun.protect ~finally:(fun () -> close_in ch)
-    (fun () ->
-       let buf = Bytes.create 4096 in
-       let rec aux () =
-         match input ch buf 0 (Bytes.length buf) with
-         | 0 -> ()
-         | n -> output dst buf 0 n; aux ()
-       in
-       aux ();
-       flush dst
-    )
-
 let write_file ~path contents =
   Lwt_io.(with_file ~mode:output) path @@ fun ch ->
   Lwt_io.write ch contents

--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -6,10 +6,6 @@ type t = {
   runc_state_dir : string;
 }
 
-type error = [`Msg of string]
-
-let pp_error f (`Msg msg) = Fmt.string f msg
-
 module Json_config = struct
   let mount ?(options=[]) ~ty ~src dst =
     `Assoc [
@@ -247,7 +243,7 @@ let copy_to_log ~src ~dst =
   let rec aux () =
     Lwt_unix.read src buf 0 (Bytes.length buf) >>= function
     | 0 -> Lwt.return_unit
-    | n -> Build_log.write dst buf 0 n >>= aux
+    | n -> Build_log.write dst (Bytes.sub_string buf 0 n) >>= aux
   in
   aux ()
 

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -1,11 +1,19 @@
 type id = string
 
+type tag = [
+  | `Heading    (** Introduces a new build step *)
+  | `Note       (** Informational output from OBuilder *)
+  | `Output     (** Raw output from the build command *)
+]
+
+type logger = tag -> string -> unit
+
 module type STORE = sig
   type t
 
   val build :
     t -> ?base:id ->
-    id:string ->
+    id:id ->
     (string -> (unit, 'e) Lwt_result.t) ->
     (unit, 'e) Lwt_result.t
   (** [build t ~id fn] runs [fn tmpdir] to add a new item to the store under
@@ -26,11 +34,7 @@ end
 module type SANDBOX = sig
   type t
 
-  type error = private [> ]
-
-  val pp_error : error Fmt.t
-
-  val run : ?stdin:Os.unix_fd -> log:Build_log.t -> t -> Config.t -> string -> (unit, error) Lwt_result.t
+  val run : ?stdin:Os.unix_fd -> log:Build_log.t -> t -> Config.t -> string -> (unit, [`Msg of string]) Lwt_result.t
   (** [run t config dir] runs the operation [config] in a sandbox with root
       filesystem [rootfs].
       @param stdin Passed to child as its standard input.

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -6,18 +6,17 @@ module type STORE = sig
   val build :
     t -> ?base:id ->
     id:string ->
-    log:out_channel ->
-    (log:Build_log.t -> string -> (unit, 'e) Lwt_result.t) ->
+    (string -> (unit, 'e) Lwt_result.t) ->
     (unit, 'e) Lwt_result.t
-  (** [build t ~id ~log fn] displays the log for build [id] on [log].
-      If it doesn't exist yet in the store, it runs [fn ~log tmpdir] to create
-      it first. On success, [tmpdir] is saved as [id], which can be used
+  (** [build t ~id fn] runs [fn tmpdir] to add a new item to the store under
+      key [id]. On success, [tmpdir] is saved as [id], which can be used
       as the [base] for further builds, until it is expired from the cache.
       On failure, nothing is recorded and calling [build] again will make
       another attempt at building it.
-      @param base Initialise [tmpdir] as a clone of [base] (with any log removed). *)
+      @param base Initialise [tmpdir] as a clone of [base]. *)
 
-  (* val path : t -> ID.t -> string *)
+  val result : t -> id -> string option
+  (** [result t id] is the path of the build result for [id], if present. *)
 
   val state_dir : t -> string
   (** [state_dir] is the path of a directory which can be used to store mutable

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -7,10 +7,10 @@ module type STORE = sig
     t -> ?base:id ->
     id:string ->
     log:out_channel ->
-    (string -> (unit, 'e) Lwt_result.t) ->
+    (log:Build_log.t -> string -> (unit, 'e) Lwt_result.t) ->
     (unit, 'e) Lwt_result.t
   (** [build t ~id ~log fn] displays the log for build [id] on [log].
-      If it doesn't exist yet in the store, it runs [fn tmpdir] to create
+      If it doesn't exist yet in the store, it runs [fn ~log tmpdir] to create
       it first. On success, [tmpdir] is saved as [id], which can be used
       as the [base] for further builds, until it is expired from the cache.
       On failure, nothing is recorded and calling [build] again will make
@@ -31,7 +31,10 @@ module type SANDBOX = sig
 
   val pp_error : error Fmt.t
 
-  val run : ?stdin:Os.unix_fd -> t -> Config.t -> string -> (unit, error) Lwt_result.t
+  val run : ?stdin:Os.unix_fd -> log:Build_log.t -> t -> Config.t -> string -> (unit, error) Lwt_result.t
   (** [run t config dir] runs the operation [config] in a sandbox with root
-      filesystem [rootfs]. *)
+      filesystem [rootfs].
+      @param stdin Passed to child as its standard input.
+      @param log Used for child's stdout and stderr.
+  *)
 end

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -59,7 +59,7 @@ let build t ?base ~id ~log fn =
     end
     >>= fun () ->
     Os.exec ["sudo"; "chown"; string_of_int (Unix.getuid ()); clone] >>= fun () ->
-    fn clone >>!= fun () ->
+    Build_log.with_log (clone / "log") (fun log -> fn ~log clone) >>!= fun () ->
     Os.exec ["sudo"; "zfs"; "snapshot"; "--"; strf "%s/%s@snap" t.pool id] >>= fun () ->
     (* ZFS can't delete the clone while the snapshot still exists. So I guess we'll just
        keep it around? *)

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -11,8 +11,6 @@ type t = {
 let path t id =
   strf "/%s/%s/.zfs/snapshot/snap" t.pool id
 
-let ( / ) = Filename.concat
-
 let check_dir x =
   match Unix.lstat x with
   | Unix.{ st_kind = S_DIR; _ } -> `Present
@@ -38,13 +36,11 @@ let delete_clone_if_exists ~pool id =
   | `Missing -> Lwt.return_unit
   | `Present -> Os.exec ["sudo"; "zfs"; "destroy"; strf "%s/%s" pool id]
 
-let build t ?base ~id ~log fn =
+let build t ?base ~id fn =
   let result = path t id in
   match check_dir result with
   | `Present ->
     Fmt.pr "%a@." (Fmt.styled (`Fg (`Yellow)) (Fmt.fmt "---> using cached result %S")) result;
-    let log_file = result / "log" in
-    if Sys.file_exists log_file then Os.cat_file log_file ~dst:log;
     Lwt_result.return ()
   | `Missing ->
     delete_clone_if_exists ~pool:t.pool id >>= fun () ->
@@ -53,14 +49,18 @@ let build t ?base ~id ~log fn =
       | None -> Os.exec ["sudo"; "zfs"; "create"; "--"; strf "%s/%s" t.pool id]
       | Some base ->
         let base = strf "%s/%s@snap" t.pool base in
-        Os.exec ["sudo"; "zfs"; "clone"; "--"; base; strf "%s/%s" t.pool id] >|= fun () ->
-        let log_file = clone / "log" in
-        if Sys.file_exists log_file then Unix.unlink log_file
+        Os.exec ["sudo"; "zfs"; "clone"; "--"; base; strf "%s/%s" t.pool id]
     end
     >>= fun () ->
     Os.exec ["sudo"; "chown"; string_of_int (Unix.getuid ()); clone] >>= fun () ->
-    Build_log.with_log (clone / "log") (fun log -> fn ~log clone) >>!= fun () ->
+    fn clone >>!= fun () ->
     Os.exec ["sudo"; "zfs"; "snapshot"; "--"; strf "%s/%s@snap" t.pool id] >>= fun () ->
     (* ZFS can't delete the clone while the snapshot still exists. So I guess we'll just
        keep it around? *)
     Lwt_result.return () 
+
+let result t id =
+  let dir = path t id in
+  match Os.check_dir dir with
+  | `Present -> Some dir
+  | `Missing -> None

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (test
   (name test)
   (deps base.tar)
-  (libraries alcotest-lwt obuilder))
+  (libraries alcotest-lwt obuilder str))
 
 (dirs :standard \ test1)

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -9,7 +9,7 @@ type t = {
 
 let expect t x = Queue.add x t.expect
 
-let run ?stdin t (config:Obuilder.Config.t) dir =
+let run ?stdin ~log:_ t (config:Obuilder.Config.t) dir =
   match Queue.take_opt t.expect with
   | None -> Fmt.failwith "Unexpected sandbox execution: %a" Fmt.(Dump.list string) config.argv
   | Some fn ->

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -1,21 +1,20 @@
-type error = [`Exn of exn]
-
-let pp_error f (`Exn ex) = Fmt.exn f ex
-
 type t = {
   dir : string;
-  expect : (?stdin:Obuilder.Os.unix_fd -> Obuilder.Config.t -> string -> unit Lwt.t) Queue.t;
+  expect : (?stdin:Obuilder.Os.unix_fd -> log:Obuilder.Build_log.t -> Obuilder.Config.t -> string -> unit Lwt.t) Queue.t;
 }
 
 let expect t x = Queue.add x t.expect
 
-let run ?stdin ~log:_ t (config:Obuilder.Config.t) dir =
+let run ?stdin ~log t (config:Obuilder.Config.t) dir =
   match Queue.take_opt t.expect with
   | None -> Fmt.failwith "Unexpected sandbox execution: %a" Fmt.(Dump.list string) config.argv
   | Some fn ->
     Lwt.try_bind
-      (fun () -> fn ?stdin config dir)
+      (fun () -> fn ?stdin ~log config dir)
       Lwt_result.return
-      (fun ex -> Lwt_result.fail (`Exn ex))
+      (function
+        | Failure ex -> Lwt_result.fail (`Msg ex)
+        | ex -> Lwt_result.fail (`Msg (Printexc.to_string ex))
+      )
 
 let create dir = { dir; expect = Queue.create () }

--- a/test/mock_sandbox.mli
+++ b/test/mock_sandbox.mli
@@ -1,5 +1,4 @@
-include Obuilder.S.SANDBOX with
-  type error = [`Exn of exn]
+include Obuilder.S.SANDBOX
 
 val create : string -> t
-val expect : t -> (?stdin:Obuilder.Os.unix_fd -> Obuilder.Config.t -> string -> unit Lwt.t) -> unit
+val expect : t -> (?stdin:Obuilder.Os.unix_fd -> log:Obuilder.Build_log.t -> Obuilder.Config.t -> string -> unit Lwt.t) -> unit

--- a/test/mock_store.ml
+++ b/test/mock_store.ml
@@ -21,7 +21,7 @@ let build t ?base ~id ~log fn =
         | Unix.WEXITED 0 -> Lwt.return_unit
         | _ -> failwith "cp failed!"
     end >>= fun () ->
-    fn dir
+    Obuilder.Build_log.with_log (dir / "log") (fun log -> fn ~log dir)
 
 let state_dir t = t.dir / "state"
 

--- a/test/mock_store.ml
+++ b/test/mock_store.ml
@@ -2,25 +2,35 @@ open Lwt.Infix
 
 module Os = Obuilder.Os
 
+let ( >>!= ) = Lwt_result.bind
 let ( / ) = Filename.concat
 
 type t = {
   dir : string;
 }
 
+let delay_store = ref Lwt.return_unit
+
 let build t ?base ~id fn =
+  base |> Option.iter (fun base -> assert (not (String.contains base '/')));
   let dir = t.dir / id in
-  match Os.check_dir dir with
-  | `Present -> Lwt_result.return ()
-  | `Missing ->
-    begin match base with
-      | None -> Os.ensure_dir dir; Lwt.return_unit
-      | Some base ->
-        Lwt_process.exec ("", [| "cp"; "-r"; t.dir / base; dir |]) >>= function
-        | Unix.WEXITED 0 -> Lwt.return_unit
-        | _ -> failwith "cp failed!"
-    end >>= fun () ->
-    fn dir
+  assert (Os.check_dir dir = `Missing);
+  let tmp_dir = dir ^ ".part" in
+  begin match base with
+    | None -> Os.ensure_dir tmp_dir; Lwt.return_unit
+    | Some base ->
+      Lwt_process.exec ("", [| "cp"; "-r"; t.dir / base; tmp_dir |]) >>= function
+      | Unix.WEXITED 0 -> Lwt.return_unit
+      | _ -> failwith "cp failed!"
+  end >>= fun () ->
+  fn tmp_dir >>= fun r ->
+  !delay_store >>= fun () ->
+  match r with
+  | Ok () ->
+    Unix.rename tmp_dir dir;
+    Lwt_result.return ()
+  | Error _ as e ->
+    Lwt.return e
 
 let state_dir t = t.dir / "state"
 

--- a/test/mock_store.ml
+++ b/test/mock_store.ml
@@ -8,8 +8,7 @@ type t = {
   dir : string;
 }
 
-let build t ?base ~id ~log fn =
-  ignore log;
+let build t ?base ~id fn =
   let dir = t.dir / id in
   match Os.check_dir dir with
   | `Present -> Lwt_result.return ()
@@ -21,7 +20,7 @@ let build t ?base ~id ~log fn =
         | Unix.WEXITED 0 -> Lwt.return_unit
         | _ -> failwith "cp failed!"
     end >>= fun () ->
-    Obuilder.Build_log.with_log (dir / "log") (fun log -> fn ~log dir)
+    fn dir
 
 let state_dir t = t.dir / "state"
 
@@ -40,3 +39,9 @@ let add t id fn =
     fn dir
 
 let path t id = t.dir / id
+
+let result t id =
+  let dir = path t id in
+  match Os.check_dir dir with
+  | `Present -> Some dir
+  | `Missing -> None

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
+open Obuilder
 
-module Builder = Obuilder.Builder(Mock_store)(Mock_sandbox)
-module Os = Obuilder.Os
+module B = Builder(Mock_store)(Mock_sandbox)
 
 let ( / ) = Filename.concat
 let ( >>!= ) = Lwt_result.bind
@@ -12,8 +12,54 @@ let () =
 let build_result =
   Alcotest.of_pp @@ fun f x ->
   match x with
-  | Error (`Exn ex) -> Fmt.exn f ex
+  | Error (`Msg msg) -> Fmt.string f msg
   | Ok id -> Fmt.string f id
+
+module Log = struct
+  type t = {
+    buf : Buffer.t;
+    cond : unit Lwt_condition.t;
+  }
+
+  let create () =
+    let buf = Buffer.create 1024 in
+    let cond = Lwt_condition.create () in
+    { buf; cond }
+
+  let add t tag x =
+    begin match tag with
+      | `Heading -> Buffer.add_string t.buf (x ^ "\n")
+      | `Output -> Buffer.add_string t.buf x
+      | `Note -> print_endline x
+    end;
+    Lwt_condition.broadcast t.cond ()
+
+  let contents t =
+    Buffer.contents t.buf
+
+  let clear t =
+    Buffer.clear t.buf
+
+  let rec await t expect =
+    let got = Buffer.contents t.buf in
+    if got = expect then Lwt.return_unit
+    else (
+      let common = min (String.length expect) (String.length got) in
+      if String.sub got 0 common = String.sub expect 0 common then (
+        Lwt_condition.wait t.cond >>= fun () ->
+        await t expect
+      ) else (
+        Fmt.failwith "Log expected %S but got %S" expect got
+      )
+    )
+
+  let check name pattern t =
+    let pattern = String.split_on_char '\n' pattern |> List.map String.trim |> String.concat "\n" in
+    let re = Str.regexp pattern in
+    let got = contents t in
+    if not (Str.string_match re got 0) then
+      Alcotest.(check string) name pattern got
+end
 
 let get store path id =
   let result = Mock_store.path store id in
@@ -22,26 +68,189 @@ let get store path id =
 let test_simple _switch () =
   Mock_store.with_store @@ fun store ->
   let sandbox = Mock_sandbox.create (Mock_store.state_dir store / "sandbox") in
-  let builder = Builder.v ~store ~sandbox in
+  let builder = B.v ~store ~sandbox in
   let src_dir = Mock_store.state_dir store / "src" in
-  Obuilder.Os.ensure_dir src_dir;
-  let context = Obuilder.Context.v ~src_dir () in
-  let spec = Obuilder.Spec.{
+  Os.ensure_dir src_dir;
+  let log = Log.create () in
+  let context = Context.v ~src_dir ~log:(Log.add log) () in
+  let spec = Spec.{
       from = "base";
       ops = [
         run "append-to base-id runner";
       ] 
     }
   in
-  Mock_sandbox.expect sandbox (fun ?stdin:_ config dir ->
+  Mock_sandbox.expect sandbox (fun ?stdin:_ ~log config dir ->
+      Build_log.printf log "Append@." >>= fun () ->
       Alcotest.(check (list string)) "Run command arguments" ["/bin/bash"; "-c"; "append-to base-id runner"] config.argv;
       let rootfs = dir / "rootfs" in
       Lwt_io.(with_file ~mode:input) (rootfs / "base-id") Lwt_io.read >>= fun orig ->
       Lwt_io.(with_file ~mode:output) (rootfs / "appended") (fun ch -> Lwt_io.write ch (orig ^ "runner"))
     );
-  Builder.build builder context spec >>!= get store "appended" >>= fun result ->
+  B.build builder context spec >>!= get store "appended" >>= fun result ->
   Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
+  Log.check "Check log" 
+    {|FROM base
+      /: (run (shell "append-to base-id runner"))
+      Append
+     |} log;
+  (* Check result is cached *)
+  Log.clear log;
+  B.build builder context spec >>!= get store "appended" >>= fun result ->
+  Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
+  Log.check "Check cached log"
+    {|FROM base
+      /: (run (shell "append-to base-id runner"))
+      Append
+     |} log;
   Lwt.return_unit
+
+(* Two builds, [A;B] and [A;C] are started together. The [A] command is only run once,
+   with the log visible to both while the build is still in progress. *)
+let test_concurrent _switch () =
+  Mock_store.with_store @@ fun store ->
+  let sandbox = Mock_sandbox.create (Mock_store.state_dir store / "sandbox") in
+  let builder = B.v ~store ~sandbox in
+  let src_dir = Mock_store.state_dir store / "src" in
+  Obuilder.Os.ensure_dir src_dir;
+  let log1 = Log.create () in
+  let log2 = Log.create () in
+  let context1 = Obuilder.Context.v ~log:(Log.add log1) ~src_dir () in
+  let context2 = Obuilder.Context.v ~log:(Log.add log2) ~src_dir () in
+  let spec1 = Obuilder.Spec.{ from = "base"; ops = [ run "A"; run "B" ] } in
+  let spec2 = Obuilder.Spec.{ from = "base"; ops = [ run "A"; run "C" ] } in
+  let a, a_done = Lwt.wait () in
+  Mock_sandbox.expect sandbox (fun ?stdin:_ ~log config dir ->
+      Alcotest.(check (list string)) "Run A" ["/bin/bash"; "-c"; "A"] config.argv;
+      Build_log.printf log "Running A@." >>= fun () ->
+      let rootfs = dir / "rootfs" in
+      Lwt_io.(with_file ~mode:output) (rootfs / "output") (fun ch -> Lwt_io.write ch "A") >>= fun () ->
+      a
+    );
+  let do_append ?stdin:_ ~log config dir =
+    match config.Config.argv with
+    | ["/bin/bash"; "-c"; cmd] ->
+      Build_log.printf log "Running %s@." cmd >>= fun () ->
+      let rootfs = dir / "rootfs" in
+      Lwt_io.(with_file ~mode:input) (rootfs / "output") Lwt_io.read >>= fun prev ->
+      Lwt_io.(with_file ~mode:output) (rootfs / "output") (fun ch -> Lwt_io.write ch (prev ^ cmd))
+    | x -> Fmt.failwith "Unexpected command %a" Fmt.(Dump.list string) x
+  in
+  Mock_sandbox.expect sandbox do_append;
+  Mock_sandbox.expect sandbox do_append;
+  let b1 = B.build builder context1 spec1 in
+  let b2 = B.build builder context2 spec2 in
+  Log.await log1 "FROM base\n/: (run (shell A))\nRunning A\n" >>= fun () ->
+  Log.await log2 "FROM base\n/: (run (shell A))\nRunning A\n" >>= fun () ->
+  Lwt.wakeup a_done ();
+  b1 >>!= get store "output" >>= fun b1 ->
+  b2 >>!= get store "output" >>= fun b2 ->
+  Alcotest.(check build_result) "Final result" (Ok "AB") b1;
+  Alcotest.(check build_result) "Final result" (Ok "AC") b2;
+  Log.check "Check AB log" 
+    {| FROM base
+       /: (run (shell A))
+       Running A
+       /: (run (shell B))
+       Running B
+     |}
+    log1;
+  Log.check "Check AC log" 
+    {| FROM base
+       /: (run (shell A))
+       Running A
+       /: (run (shell C))
+       Running C
+     |}
+    log2;
+  Lwt.return ()
+
+(* Two builds, [A;B] and [A;C] are started together. The [A] command fails. *)
+let test_concurrent_failure _switch () =
+  Mock_store.with_store @@ fun store ->
+  let sandbox = Mock_sandbox.create (Mock_store.state_dir store / "sandbox") in
+  let builder = B.v ~store ~sandbox in
+  let src_dir = Mock_store.state_dir store / "src" in
+  Obuilder.Os.ensure_dir src_dir;
+  let log1 = Log.create () in
+  let log2 = Log.create () in
+  let context1 = Obuilder.Context.v ~log:(Log.add log1) ~src_dir () in
+  let context2 = Obuilder.Context.v ~log:(Log.add log2) ~src_dir () in
+  let spec1 = Obuilder.Spec.{ from = "base"; ops = [ run "A"; run "B" ] } in
+  let spec2 = Obuilder.Spec.{ from = "base"; ops = [ run "A"; run "C" ] } in
+  let a, a_done = Lwt.wait () in
+  Mock_sandbox.expect sandbox (fun ?stdin:_ ~log config _dir ->
+      Alcotest.(check (list string)) "Run A" ["/bin/bash"; "-c"; "A"] config.argv;
+      Build_log.printf log "Running A@." >>= fun () ->
+      a >>= fun () ->
+      Lwt.fail_with "Mock build failure"
+    );
+  let b1 = B.build builder context1 spec1 in
+  let b2 = B.build builder context2 spec2 in
+  Log.await log1 "FROM base\n/: (run (shell A))\nRunning A\n" >>= fun () ->
+  Log.await log2 "FROM base\n/: (run (shell A))\nRunning A\n" >>= fun () ->
+  Lwt.wakeup a_done ();
+  b1 >>!= get store "output" >>= fun b1 ->
+  b2 >>!= get store "output" >>= fun b2 ->
+  Alcotest.(check build_result) "B1 result" (Error (`Msg "Mock build failure")) b1;
+  Alcotest.(check build_result) "B2 result" (Error (`Msg "Mock build failure")) b2;
+  Log.check "Check AB log" 
+    {| FROM base
+       /: (run (shell A))
+       Running A
+     |}
+    log1;
+  Log.check "Check AC log" 
+    {| FROM base
+       /: (run (shell A))
+       Running A
+     |}
+    log2;
+  Lwt.return ()
+
+(* Two builds, [A;B] and [A;C] are started together. The [A] command fails
+   just as the second build is trying to open the log file. *)
+let test_concurrent_failure_2 _switch () =
+  Mock_store.with_store @@ fun store ->
+  let sandbox = Mock_sandbox.create (Mock_store.state_dir store / "sandbox") in
+  let builder = B.v ~store ~sandbox in
+  let src_dir = Mock_store.state_dir store / "src" in
+  Obuilder.Os.ensure_dir src_dir;
+  let log1 = Log.create () in
+  let log2 = Log.create () in
+  let context1 = Obuilder.Context.v ~log:(Log.add log1) ~src_dir () in
+  let context2 = Obuilder.Context.v ~log:(Log.add log2) ~src_dir () in
+  let spec1 = Obuilder.Spec.{ from = "base"; ops = [ run "A"; run "B" ] } in
+  let spec2 = Obuilder.Spec.{ from = "base"; ops = [ run "A"; run "C" ] } in
+  let a, a_done = Lwt.wait () in
+  Mock_sandbox.expect sandbox (fun ?stdin:_ ~log config _dir ->
+      Mock_store.delay_store := a;
+      Alcotest.(check (list string)) "Run A" ["/bin/bash"; "-c"; "A"] config.argv;
+      Build_log.printf log "Running A@." >>= fun () ->
+      Lwt.fail_with "Mock build failure"
+    );
+  let b1 = B.build builder context1 spec1 in
+  Log.await log1 "FROM base\n/: (run (shell A))\nRunning A\n" >>= fun () ->
+  let b2 = B.build builder context2 spec2 in
+  Log.await log2 "FROM base\n/: (run (shell A))\n" >>= fun () ->
+  Lwt.wakeup a_done ();
+  b1 >>!= get store "output" >>= fun b1 ->
+  b2 >>!= get store "output" >>= fun b2 ->
+  Alcotest.(check build_result) "B1 result" (Error (`Msg "Mock build failure")) b1;
+  Alcotest.(check build_result) "B2 result" (Error (`Msg "Mock build failure")) b2;
+  Log.check "Check AB log" 
+    {| FROM base
+       /: (run (shell A))
+       Running A
+     |}
+    log1;
+  Log.check "Check AC log" 
+    {| FROM base
+       /: (run (shell A))
+       Running A
+     |}
+    log2;
+  Lwt.return ()
 
 let sexp = Alcotest.of_pp Sexplib.Sexp.pp_hum
 
@@ -49,8 +258,8 @@ let sexp = Alcotest.of_pp Sexplib.Sexp.pp_hum
 let test_sexp () =
   let test name s =
     let s1 = Sexplib.Sexp.of_string s in
-    let stage = Obuilder.Spec.stage_of_sexp s1 in
-    let s2 = Obuilder.Spec.sexp_of_stage stage in
+    let stage = Spec.stage_of_sexp s1 in
+    let s2 = Spec.sexp_of_stage stage in
     Alcotest.(check sexp) name s1 s2
   in
   test "copy" {|
@@ -73,6 +282,9 @@ let () =
       ];
       "build", [
         test_case "Simple"     `Quick test_simple;
+        test_case "Concurrent" `Quick test_concurrent;
+        test_case "Concurrent failure" `Quick test_concurrent_failure;
+        test_case "Concurrent failure 2" `Quick test_concurrent_failure_2;
       ];
     ]
   end


### PR DESCRIPTION
This also simplifies the logic for the individual store backends, by moving log handling to the `Db_store` wrapper.