### PR TITLE
Fix some logging bugs

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -149,7 +149,6 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
       )
 
   let build t context { Spec.from = base; ops } =
-    Fmt.pr "%a@." (Fmt.styled (`Fg (`Hi `Blue)) (Fmt.fmt "FROM %S")) base;
     get_base t ~log:context.Context.log base >>!= fun template_dir ->
     run_steps t ~context ~base:template_dir ops
 

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -64,9 +64,11 @@ let finish t =
     t.state <- `Finished;
     Lwt_unix.close fd >|= fun () ->
     Lwt_condition.broadcast cond ()
-  | `Readonly _ | `Empty ->
+  | `Readonly _ ->
     t.state <- `Finished;
     Lwt.return_unit
+  | `Empty ->
+    Lwt.return_unit (* Empty can be reused *)
 
 let write t data =
   match t.state with


### PR DESCRIPTION
1. Ignore requests to close the `empty` singleton log.
2. Ensure we finishing tailing the log before continuing.