### PR TITLE
Add some notes to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,38 @@ As present, the initial base image is fetched from Docker Hub using `docker pull
 
 ## Usage
 
-OBuilder is intended to be used as a library, but at the moment there is just a command-line interface.
+OBuilder is designed to be used as a component of a build scheduler such as [OCluster][].
+However, there is also a command-line interface for testing.
 
 To build `example.spec` (which builds OBuilder itself) using the ZFS pool `tank` to cache the build results:
 
     $ obuilder build -f example.spec . --store=zfs:tank
 
 To use Btrfs directory `/mnt/btrfs` for the build cache, use `--store=btrfs:/mnt/btrfs`.
+
+## Notes
+
+Some operations (such as deleting btrfs snapshots) require root access.
+OBuilder currently uses `sudo` as necessary for such operations.
+
+You should only run one instance of the command-line client at a time with
+a given store. OBuilder does support concurrent builds, but they must be
+performed using a single builder object:
+
+- If you try to perform an operation that is already being performed by another
+  build, it will just attach to the existing build.
+
+- The new client will get the logs so far, and then stream new log data as it
+  arrives.
+
+- If a client cancels, it just stops following the log.
+  The operation itself is cancelled if all its clients cancel.
+
+OBuilder calculates a digest of the input files to decide whether a `copy` step
+needs to be repeated. However, if it decides to copy the file to the build sandbox,
+it does not check the digest again. Therefore, you must not modify the input
+files while a build is in progress.
+
+Failed build steps are not cached.
+
+[OCluster]: https://github.com/ocurrent/ocluster

--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -35,7 +35,10 @@ module Make (Raw : S.STORE) = struct
 
   let dec_ref t ~id build =
     build.users <- build.users - 1;
-    Log.info (fun f -> f "User cancelled job (users now = %d)" build.users);
+    Log.info (fun f ->
+        if Lwt.is_sleeping build.result then
+          f "User cancelled job (users now = %d)" build.users
+      );
     if build.users = 0 then (
       (* Remove it immediately, so that no other user can try to attach to it. *)
       t.in_progress <- Builds.remove id t.in_progress;


### PR DESCRIPTION
Also, only log messages about cancellations if the build isn't already finished, as it's common to turn off the switch after a successful build.