### PR TITLE
Add Docker BuildKit-format conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,6 @@ A mutable copy of the cache is created for the command. When the command finishe
 this copy becomes the new version of the cache, unless some other command updated the same cache first, in
 which case this one is discarded.
 
-`NAME` must match the regexp `[A-Za-z][-._A-Za-z0-9]*`.
-
 ### copy
 
 ```sexp
@@ -245,10 +243,8 @@ The dockerfile should work the same way as the spec file, except for these limit
 
 - In `(copy (excludes ...) ...)` the excludes part is ignored.
   You will need to ensure you have a suitable `.dockerignore` file instead.
-- In `(run (cache ...) ...)` the caches are ignored, as regular Docker doesn't support this.
-  It would be possible to switch to the extended BuildKit format in this case,
-  but the normal use is to let users duplicate a build easily, and
-  it's easier if they don't need to set up BuildKit.
+
+- If you want to include caches, use `--buildkit` to output in the extended BuildKit syntax.
 
 
 [Dockerfile]: https://docs.docker.com/engine/reference/builder/

--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -15,7 +15,7 @@ type cache = {
 
 type t = {
   root : string;        (* The top-level directory (containing `result`, etc). *)
-  caches : (Obuilder_spec.cache_id, cache) Hashtbl.t;
+  caches : (string, cache) Hashtbl.t;
   mutable next : int;   (* Used to generate unique temporary IDs. *)
 }
 
@@ -63,8 +63,8 @@ module Path = struct
   let result t id        = t.root / "result" / id
   let result_tmp t id    = t.root / "result-tmp" / id
   let state t            = t.root / "state"
-  let cache t name       = t.root / "cache" / (name : Obuilder_spec.cache_id :> string)
-  let cache_tmp t i name = t.root / "cache-tmp" / strf "%d-%s" i (name : Obuilder_spec.cache_id :> string)
+  let cache t name       = t.root / "cache" / Escape.cache name
+  let cache_tmp t i name = t.root / "cache-tmp" / strf "%d-%s" i (Escape.cache name)
 end
 
 let delete t id =
@@ -110,7 +110,7 @@ let result t id =
   | `Present -> Some dir
   | `Missing -> None
 
-let get_cache t (name : Obuilder_spec.cache_id) =
+let get_cache t name =
   match Hashtbl.find_opt t.caches name with
   | Some c -> c
   | None ->

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -58,7 +58,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
         let to_release = ref [] in
         Lwt.finalize
           (fun () ->
-             cache |> Lwt_list.map_s (fun { Obuilder_spec.id; target } ->
+             cache |> Lwt_list.map_s (fun { Obuilder_spec.Cache.id; target; buildkit_options = _ } ->
                  Store.cache ~user t.store id >|= fun (src, release) ->
                  to_release := release :: !to_release;
                  { Config.Mount.src; dst = target }

--- a/lib/db_store.mli
+++ b/lib/db_store.mli
@@ -21,7 +21,7 @@ module Make (Raw : S.STORE) : sig
   val cache :
     user : Obuilder_spec.user ->
     t ->
-    Obuilder_spec.cache_id ->
+    string ->
     (string * (unit -> unit Lwt.t)) Lwt.t
 
   val wrap : Raw.t -> t

--- a/lib/escape.ml
+++ b/lib/escape.ml
@@ -1,0 +1,11 @@
+(* Make a cache name safe to use as a filename.
+   Different inputs must always produce different outputs.
+   The output string will match /[-._A-Za-z0-9%]+/. *)
+let cache x =
+  let b = Buffer.create (String.length x * 2) in
+  Buffer.add_string b "c-";
+  x |> String.iter (function
+      | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' as c -> Buffer.add_char b c
+      | c -> Buffer.add_string b (Printf.sprintf "%%%x" (Char.code c))
+    );
+  Buffer.contents b

--- a/lib/obuilder.ml
+++ b/lib/obuilder.ml
@@ -19,3 +19,4 @@ module Store_spec = Store_spec
 
 (* For unit-tests *)
 module Manifest = Manifest
+module Escape = Escape

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -41,7 +41,7 @@ module type STORE = sig
   val cache :
     user:Obuilder_spec.user ->
     t ->
-    Obuilder_spec.cache_id ->
+    string ->
     (string * (unit -> unit Lwt.t)) Lwt.t
   (** [cache ~user t name] creates a writeable copy of the latest snapshot of the
       cache [name]. It returns the path of this fresh copy and a function which
@@ -52,7 +52,7 @@ module type STORE = sig
       version of the cache, unless the cache has already been updated since
       it was snapshotted, in which case this writeable copy is simply discarded. *)
 
-  val delete_cache : t -> Obuilder_spec.cache_id -> (unit, [> `Busy]) Lwt_result.t
+  val delete_cache : t -> string -> (unit, [> `Busy]) Lwt_result.t
   (** [delete_cache t name] removes the cache [name], if present.
       If the cache is currently in use, the store may instead return [Error `Busy]. *)
 end

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -32,7 +32,7 @@ type cache = {
 
 type t = {
   pool : string;
-  caches : (Obuilder_spec.cache_id, cache) Hashtbl.t;
+  caches : (string, cache) Hashtbl.t;
   mutable next : int;
 }
 
@@ -46,8 +46,8 @@ module Dataset : sig
   val groups : dataset list
 
   val result : S.id -> dataset
-  val cache : Obuilder_spec.cache_id -> dataset
-  val cache_tmp : int -> Obuilder_spec.cache_id -> dataset
+  val cache : string -> dataset
+  val cache_tmp : int -> string -> dataset
 
   val full_name : ?snapshot:string -> t -> dataset -> string
   val path : ?snapshot:string -> t -> dataset -> string
@@ -65,8 +65,8 @@ end = struct
   let groups = [state; result_group; cache_group; cache_tmp_group]
 
   let result id = "result/" ^ id
-  let cache (name : Obuilder_spec.cache_id) = "cache/" ^ (name :> string)
-  let cache_tmp i (name : Obuilder_spec.cache_id) = strf "cache-tmp/%d-%s" i (name :> string)
+  let cache name = "cache/" ^ Escape.cache name
+  let cache_tmp i name = strf "cache-tmp/%d-%s" i (Escape.cache name)
 
   let full_name ?snapshot t ds =
     match snapshot with
@@ -197,7 +197,7 @@ let result t id =
   if Sys.file_exists path then Some path
   else None
 
-let get_cache t (name : Obuilder_spec.cache_id) =
+let get_cache t name =
   match Hashtbl.find_opt t.caches name with
   | Some c -> c
   | None ->

--- a/lib_spec/cache.ml
+++ b/lib_spec/cache.ml
@@ -1,0 +1,20 @@
+open Sexplib.Std
+open Sexplib.Sexp
+
+type t = {
+  id : string;
+  target : string;
+  buildkit_options : (string * string) list [@sexp.list];
+} [@@deriving sexp]
+
+let t_of_sexp x =
+  match x with
+  | List (Atom id :: fields) -> t_of_sexp (List (List [Atom "id"; Atom id] :: fields))
+  | x -> Fmt.failwith "Invalid cache: %a" Sexplib.Sexp.pp_hum x
+
+let sexp_of_t x =
+  match sexp_of_t x with
+  | List (List [Atom "id"; Atom id] :: fields) -> List (Atom id :: fields)
+  | x -> Fmt.failwith "Invalid cache: %a" Sexplib.Sexp.pp_hum x
+
+let v ?(buildkit_options=[]) ~target id = { id; target; buildkit_options }

--- a/lib_spec/cache.mli
+++ b/lib_spec/cache.mli
@@ -1,0 +1,8 @@
+type t = {
+  id : string;
+  target : string;
+  buildkit_options : (string * string) list;        (* Only used when converting to Docker BuildKit format. *)
+} [@@deriving sexp]
+
+val v : ?buildkit_options:(string * string) list -> target:string -> string -> t
+(** [v ~target id] mounts cache [id] at [target]. *)

--- a/lib_spec/docker.ml
+++ b/lib_spec/docker.ml
@@ -8,10 +8,28 @@ let default_ctx = {
   user = Spec.root;
 }
 
-let of_op (acc, ctx) : Spec.op -> Dockerfile.t list * ctx = function
+(* Note: could do with some escaping here, but the rules are not clear. *)
+let pp_pair f (k, v) =
+  Fmt.pf f "%s=%s" k v
+
+let of_op ~buildkit (acc, ctx) : Spec.op -> Dockerfile.t list * ctx = function
   | `Comment x -> comment "%s" x :: acc, ctx
   | `Workdir x -> workdir "%s" x :: acc, ctx
   | `Shell xs -> shell xs :: acc, ctx
+  | `Run { cache = (_ :: _) as cache; shell } when buildkit ->
+    let mounts =
+      cache |> List.map (fun { Cache.id; target; buildkit_options } ->
+          let buildkit_options =
+            ("--mount=type", "cache") ::
+            ("id", id) ::
+            ("target", target) ::
+            ("uid", string_of_int ctx.user.uid) ::
+            buildkit_options
+          in
+          Fmt.strf "@[<h>%a@]" Fmt.(list ~sep:(unit ",") pp_pair) buildkit_options
+        )
+    in
+    run "%s %s" (String.concat " " mounts) shell :: acc, ctx
   | `Run { cache = _; shell } -> run "%s" shell :: acc, ctx
   | `Copy { src; dst; exclude = _ } ->
     if ctx.user = Spec.root then copy ~src ~dst () :: acc, ctx
@@ -23,6 +41,6 @@ let of_op (acc, ctx) : Spec.op -> Dockerfile.t list * ctx = function
   | `User ({ uid; gid } as u) -> user "%d:%d" uid gid :: acc, { user = u }
   | `Env b -> env [b] :: acc, ctx
 
-let dockerfile_of_spec { Spec.from; ops } =
-  let ops', _ctx = List.fold_left of_op ([], default_ctx) ops in
+let dockerfile_of_spec ~buildkit { Spec.from; ops } =
+  let ops', _ctx = List.fold_left (of_op ~buildkit) ([], default_ctx) ops in
   Dockerfile.from from @@@ List.rev ops'

--- a/lib_spec/docker.mli
+++ b/lib_spec/docker.mli
@@ -1,11 +1,11 @@
-val dockerfile_of_spec : Spec.stage -> Dockerfile.t
+val dockerfile_of_spec : buildkit:bool -> Spec.stage -> Dockerfile.t
 (** [dockerfile_of_spec x] produces a Dockerfile that aims to be equivalent to [x].
 
     However, note that:
 
     - In "(copy (excludes ...) ...)" the excludes part is ignored. You will need to ensure
       you have a suitable ".dockerignore" file.
-    - In "(run (cache ...) ...)" the caches are ignored. Regular Docker doesn't support this.
-      It would be possible to switch to the extended BuildKit format in this case, but the
-      normal use for [dockerfile_of_spec] is to let users duplicate a build easily, and
-      it's easier if they don't need to set up BuildKit. *)
+    - The conversion is not robust against malicious input, as the escaping rules are unclear.
+
+    @param buildkit If true, the extended BuildKit syntax is used to support caches.
+                    If false, caches are ignored. *)

--- a/lib_spec/obuilder_spec.ml
+++ b/lib_spec/obuilder_spec.ml
@@ -1,3 +1,4 @@
 include Spec
 
+module Cache = Cache
 module Docker = Docker

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -1,20 +1,5 @@
 open Sexplib.Std
 
-type cache_id = string
-
-let cache_id = function
-  | "" -> Fmt.error_msg "Cache ID is empty!"
-  | name ->
-    let p = function
-      | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '-' | '_' -> true
-      | _ -> false
-    in
-    if Astring.String.for_all p name then (
-      match name.[0] with
-      | 'A' .. 'Z' | 'a' .. 'z' -> Ok name
-      | _ -> Fmt.error_msg "Cache ID %S should start with [A-Za-z]" name
-    ) else Fmt.error_msg "Invalid character in cache ID %S (should be [-._A-Za-z0-9])" name
-
 (* Convert fields matched by [p] from (name v1 v2 ...) to (name (v1 v2 ...)) *)
 let inflate_record p =
   let open Sexplib.Sexp in function
@@ -53,28 +38,10 @@ let sexp_of_copy x = deflate_record copy_inlined (sexp_of_copy x)
 type user = { uid : int; gid : int }
 [@@deriving sexp]
 
-type cache = {
-  id : string;
-  target : string;
-} [@@deriving sexp]
-
-let cache_of_sexp x =
-  let open Sexplib.Sexp in
-  match x with
-  | List (Atom id :: fields) -> cache_of_sexp (List (List [Atom "id"; Atom id] :: fields))
-  | x -> Fmt.failwith "Invalid cache: %a" Sexplib.Sexp.pp_hum x
-
-let sexp_of_cache x =
-  let open Sexplib.Sexp in
-  match sexp_of_cache x with
-  | List (List [Atom "id"; Atom id] :: fields) -> List (Atom id :: fields)
-  | x -> Fmt.failwith "Invalid cache: %a" Sexplib.Sexp.pp_hum x
-
 type run = {
-  cache : cache list [@sexp.list];
+  cache : Cache.t list [@sexp.list];
   shell : string;
-}
-[@@deriving sexp]
+} [@@deriving sexp]
 
 let run_inlined = function
   | "cache" -> true

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -1,7 +1,3 @@
-type cache_id = private string
-
-val cache_id : string -> (cache_id, [> `Msg of string]) result
-
 type copy = {
   src : string list;
   dst : string;
@@ -13,13 +9,8 @@ type user = {
   gid : int
 } [@@deriving sexp]
 
-type cache = {
-  id : cache_id;
-  target : string;
-} [@@deriving sexp]
-
 type run = {
-  cache : cache list;
+  cache : Cache.t list;
   shell : string;
 } [@@deriving sexp]
 
@@ -43,7 +34,7 @@ val stage : from:string -> op list -> stage
 val comment : ('a, unit, string, op) format4 -> 'a
 val workdir : string -> op
 val shell : string list -> op
-val run : ?cache:cache list -> ('a, unit, string, op) format4 -> 'a
+val run : ?cache:Cache.t list -> ('a, unit, string, op) format4 -> 'a
 val copy : ?exclude:string list -> string list -> dst:string -> op
 val env : string -> string -> op
 val user : uid:int -> gid:int -> op

--- a/main.ml
+++ b/main.ml
@@ -50,10 +50,10 @@ let delete store id =
     Builder.delete builder id ~log:(fun id -> Fmt.pr "Removing %s@." id)
   end
 
-let dockerfile spec =
+let dockerfile buildkit spec =
   Sexplib.Sexp.load_sexp spec
   |> Obuilder_spec.stage_of_sexp
-  |> Obuilder_spec.Docker.dockerfile_of_spec 
+  |> Obuilder_spec.Docker.dockerfile_of_spec ~buildkit
   |> Dockerfile.string_of_t
   |> print_endline
 
@@ -104,9 +104,16 @@ let delete =
   Term.(const delete $ store $ id),
   Term.info "delete" ~doc
 
+let buildkit =
+  Arg.value @@
+  Arg.flag @@
+  Arg.info
+    ~doc:"Output extended BuildKit syntax"
+    ["buildkit"]
+
 let dockerfile =
   let doc = "Convert a spec to Dockerfile format" in
-  Term.(const dockerfile $ spec_file),
+  Term.(const dockerfile $ buildkit $ spec_file),
   Term.info "dockerfile" ~doc
 
 let cmds = [build; delete; dockerfile]

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -56,7 +56,7 @@ module Test(Store : S.STORE) = struct
     let uid = Unix.getuid () in
     let gid = Unix.getgid () in
     let user = { Spec.uid = 123; gid = 456 } in
-    let id = Spec.cache_id "c1" |> Result.get_ok in
+    let id = "c1" in
     (* Create a new cache *)
     Store.delete_cache t id >>= fun x ->
     assert (x = Ok ());
@@ -110,7 +110,7 @@ module Test(Store : S.STORE) = struct
   let n_jobs = 100
   let max_running = 10
 
-  let stress_cache = Spec.cache_id "stress" |> Result.get_ok
+  let stress_cache = "stress"
 
   (* A build of [n_steps] where each step appends a random number in 0..!n_values to `output` *)
   let random_build () =
@@ -119,7 +119,7 @@ module Test(Store : S.STORE) = struct
       | i -> Random.int n_values :: aux (i - 1)
     in
     let items = aux n_steps in
-    let cache = [ { Spec.id = stress_cache; target = "/mnt" } ] in
+    let cache = [ Spec.Cache.v stress_cache ~target:"/mnt" ] in
     let ops = items |> List.map (fun i -> Spec.run ~cache "echo -n %d >> output; echo 'added:%d'" i i) in
     let expected = items |> List.map string_of_int |> String.concat "" in
     let ops = ops @ [Spec.run {|[ `cat output` = %S ] || exit 1|} expected] in


### PR DESCRIPTION
Also, remove cache naming restrictions.
Instead, have the backends escape the name as necessary if they need to.