### PR TITLE
Support copying paths with longer names

### DIFF
--- a/.run-travis-tests.sh
+++ b/.run-travis-tests.sh
@@ -22,14 +22,14 @@ opam exec -- dune exec -- ./stress/stress.exe btrfs:/btrfs
 opam exec -- dune exec -- ./stress/stress.exe zfs:zfs
 
 # Populate the caches from our own Travis cache
-btrfs subvolume create /btrfs/cache/opam-archives
-cp -r ~/.opam/download-cache/* /btrfs/cache/opam-archives/
-sudo chown -R 1000:1000 /btrfs/cache/opam-archives
+btrfs subvolume create /btrfs/cache/c-opam-archives
+cp -r ~/.opam/download-cache/* /btrfs/cache/c-opam-archives/
+sudo chown -R 1000:1000 /btrfs/cache/c-opam-archives
 
-sudo zfs create zfs/cache/opam-archives
-sudo cp -r ~/.opam/download-cache/* /zfs/cache/opam-archives/
-sudo chown -R 1000:1000 /zfs/cache/opam-archives
-sudo zfs snapshot zfs/cache/opam-archives@snap
+sudo zfs create zfs/cache/c-opam-archives
+sudo cp -r ~/.opam/download-cache/* /zfs/cache/c-opam-archives/
+sudo chown -R 1000:1000 /zfs/cache/c-opam-archives
+sudo zfs snapshot zfs/cache/c-opam-archives@snap
 
 opam exec -- dune exec -- obuilder build -f example.spec . --store=btrfs:/btrfs
 opam exec -- dune exec -- obuilder build -f example.spec . --store=zfs:zfs

--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -2,6 +2,8 @@ open Lwt.Infix
 
 let strf = Printf.sprintf
 
+let running_as_root = Unix.getuid () = 0
+
 (* Represents a persistent cache.
    You must hold a cache's lock when removing or updating its entry in
    "cache", and must assume this may happen at any time when not holding it.
@@ -24,7 +26,7 @@ let ( / ) = Filename.concat
 module Btrfs = struct
   let btrfs ?(sudo=false) args =
     let args = "btrfs" :: args in
-    let args = if sudo then "sudo" :: args else args in
+    let args = if sudo && not running_as_root then "sudo" :: args else args in
     Os.exec ~stdout:`Dev_null args
 
   let subvolume_create path =

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -176,7 +176,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     Store.build t.store ~id ~log (fun ~cancelled:_ ~log:_ tmp ->
         Fmt.pr "Base image not present; importing %S...@." base;
         let rootfs = tmp / "rootfs" in
-        Unix.mkdir rootfs 0o755;
+        Os.sudo ["mkdir"; "--mode=755"; "--"; rootfs] >>= fun () ->
         (* Lwt_process.exec ("", [| "docker"; "pull"; "--"; base |]) >>= fun _ -> *)
         Os.pread ["docker"; "create"; "--"; base] >>= fun cid ->
         let cid = String.trim cid in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -106,14 +106,14 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
       let id = Sha256.to_hex (Sha256.string (Sexplib.Sexp.to_string (sexp_of_copy_details details))) in
       Store.build t.store ?switch ~base ~id ~log (fun ~cancelled ~log result_tmp ->
           let argv = ["tar"; "-xf"; "-"] in
-          let config = Config.v ~cwd:"/" ~argv ~hostname ~user ~env:["PATH", "/bin:/usr/bin"] ~mounts:[] in
+          let config = Config.v ~cwd:"/" ~argv ~hostname ~user:Obuilder_spec.root ~env:["PATH", "/bin:/usr/bin"] ~mounts:[] in
           Os.with_pipe_to_child @@ fun ~r:from_us ~w:to_untar ->
           let proc = Sandbox.run ~cancelled ~stdin:from_us ~log t.sandbox config result_tmp in
           let send =
             (* If the sending thread finishes (or fails), close the writing socket
                immediately so that the tar process finishes too. *)
             Lwt.finalize
-              (fun () -> Tar_transfer.send_files ~src_dir ~src_manifest ~dst ~to_untar)
+              (fun () -> Tar_transfer.send_files ~src_dir ~src_manifest ~dst ~to_untar ~user)
               (fun () -> Lwt_unix.close to_untar)
           in
           proc >>= fun result ->

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -36,6 +36,12 @@ let exec ?cwd ?stdin ?stdout ?stderr argv =
   | Ok n -> Lwt.fail_with (Fmt.strf "%t failed with exit status %d" pp n)
   | Error (`Msg m) -> Lwt.fail (Failure m)
 
+let running_as_root = Unix.getuid () = 0
+
+let sudo args =
+  let args = if running_as_root then args else "sudo" :: args in
+  exec args
+
 let with_open_out path fn =
   Lwt_unix.openfile path Unix.[O_RDWR; O_CREAT; O_EXCL] 0o666 >>= fun fd ->
   Lwt.finalize

--- a/lib/tar_transfer.ml
+++ b/lib/tar_transfer.ml
@@ -33,7 +33,7 @@ module Tar_lwt_unix = struct
   module HW = Tar.HeaderWriter(Lwt)(Writer)
 
   let write_block (header: Tar.Header.t) (body: Lwt_unix.file_descr -> unit Lwt.t) (fd : Lwt_unix.file_descr) =
-    HW.write header fd
+    HW.write ~level:Tar.Header.Ustar header fd
     >>= fun () ->
     body fd >>= fun () ->
     Writer.really_write fd (Tar.Header.zero_padding header)

--- a/lib/tar_transfer.mli
+++ b/lib/tar_transfer.mli
@@ -2,8 +2,10 @@ val send_files :
   src_dir:string ->
   src_manifest:Manifest.t list ->        (* Better name? *)
   dst:string ->
+  user:Obuilder_spec.user ->
   to_untar:Lwt_unix.file_descr ->
   unit Lwt.t
-(** [send_files ~src_dir ~src_manifest ~dst ~to_untar] writes a tar-format stream
+(** [send_files ~src_dir ~src_manifest ~dst ~user ~to_untar] writes a tar-format stream
     to [to_untar] containing all the files listed in [src_manifest], which are
-    loaded from [src_dir]. The file names in the stream are prefixed with [dst]. *)
+    loaded from [src_dir]. The file names in the stream are prefixed with [dst].
+    All files are listed as being owned by [user]. *)

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -93,10 +93,10 @@ let user = { Obuilder_spec.uid = Unix.getuid (); gid = Unix.getgid () }
 module Zfs = struct
   let chown ~user t ds =
     let { Obuilder_spec.uid; gid } = user in
-    Os.exec ["sudo"; "chown"; strf "%d:%d" uid gid; Dataset.path t ds]
+    Os.sudo ["chown"; strf "%d:%d" uid gid; Dataset.path t ds]
 
   let create t ds =
-    Os.exec ["sudo"; "zfs"; "create"; "--"; Dataset.full_name t ds]
+    Os.sudo ["zfs"; "create"; "--"; Dataset.full_name t ds]
 
   let destroy t ds mode =
     let opts =
@@ -105,7 +105,7 @@ module Zfs = struct
       | `And_snapshots -> ["-r"]
       | `And_snapshots_and_clones -> ["-R"]
     in
-    Os.exec (["sudo"; "zfs"; "destroy"] @ opts @ ["--"; Dataset.full_name t ds])
+    Os.sudo (["zfs"; "destroy"] @ opts @ ["--"; Dataset.full_name t ds])
 
   let destroy_snapshot t ds snapshot mode =
     let opts =
@@ -114,24 +114,24 @@ module Zfs = struct
       | `Recurse -> ["-R"]
       | `Immediate -> []
     in
-    Os.exec (["sudo"; "zfs"; "destroy"] @ opts @ ["--"; Dataset.full_name t ds ^ "@" ^ snapshot])
+    Os.sudo (["zfs"; "destroy"] @ opts @ ["--"; Dataset.full_name t ds ^ "@" ^ snapshot])
 
   let clone t ~src ~snapshot dst =
-    Os.exec ["sudo"; "zfs"; "clone"; "--"; Dataset.full_name t src ~snapshot; Dataset.full_name t dst]
+    Os.sudo ["zfs"; "clone"; "--"; Dataset.full_name t src ~snapshot; Dataset.full_name t dst]
 
   let snapshot t ds ~snapshot =
-    Os.exec ["sudo"; "zfs"; "snapshot"; "--"; Dataset.full_name t ds ~snapshot]
+    Os.sudo ["zfs"; "snapshot"; "--"; Dataset.full_name t ds ~snapshot]
 
   let promote t ds =
-    Os.exec ["sudo"; "zfs"; "promote"; Dataset.full_name t ds]
+    Os.sudo ["zfs"; "promote"; Dataset.full_name t ds]
 
   let rename t ~old ds =
-    Os.exec ["sudo"; "zfs"; "rename"; "--"; Dataset.full_name t old; Dataset.full_name t ds]
+    Os.sudo ["zfs"; "rename"; "--"; Dataset.full_name t old; Dataset.full_name t ds]
 
   let rename_snapshot t ds ~old snapshot =
-    Os.exec ["sudo"; "zfs"; "rename"; "--";
-             Dataset.full_name t ds ~snapshot:old;
-             Dataset.full_name t ds ~snapshot]
+    Os.sudo ["zfs"; "rename"; "--";
+          Dataset.full_name t ds ~snapshot:old;
+          Dataset.full_name t ds ~snapshot]
 end
 
 let delete_if_exists t ds mode =


### PR DESCRIPTION
Use ustar tar format for copying files, raising the limit from 100 bytes to at least 155 bytes and (depending on the path) up to 256 bytes.

ocaml-tar also allows you to select the `Posix` level, which should allow unlimited file lengths. However, this appears to be unimplemented for archive creation.