### PR TITLE
Add syntax for configuring networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The command run will be this list of arguments followed by the single argument `
 ```sexp
 (run
  (cache CACHE...)?
+ (network NETWORK...)?
  (shell COMMAND))
  
 ```
@@ -142,6 +143,7 @@ Examples:
 ```sexp
 (run
  (cache (opam-archives (target /home/opam/.opam/download-cache)))
+ (network host)
  (shell "opam install utop"))
 ```
 
@@ -156,6 +158,13 @@ owned by the user in the build context.
 A mutable copy of the cache is created for the command. When the command finishes (whether successful or not)
 this copy becomes the new version of the cache, unless some other command updated the same cache first, in
 which case this one is discarded.
+
+The `(network NETWORK...)` field specifies which network(s) the container will be connected to.
+`(network host)` is a special value which runs the container in the host's network namespace.
+Otherwise, a fresh network namespace is created for the container, with interfaces for the given
+networks (if any).
+
+Currently, no other networks can be used, so the only options are `host` or an isolated private network.
 
 ### copy
 
@@ -245,6 +254,9 @@ The dockerfile should work the same way as the spec file, except for these limit
   You will need to ensure you have a suitable `.dockerignore` file instead.
 
 - If you want to include caches, use `--buildkit` to output in the extended BuildKit syntax.
+
+- All `(network ...)` fields are ignored, as Docker does not allow per-step control of
+  networking.
 
 
 [Dockerfile]: https://docs.docker.com/engine/reference/builder/

--- a/example.spec
+++ b/example.spec
@@ -11,7 +11,9 @@
  (user (uid 1000) (gid 1000))                           ; Build as the "opam" user
  (run (shell "sudo chown opam /src"))
  (env OPAM_HASH "3332c004db65ef784f67efdadc50982f000b718f") ; Fix the version of opam-repository we want
- (run (shell
+ (run 
+  (network host)
+  (shell
    "cd ~/opam-repository \
     && (git cat-file -e $OPAM_HASH || git fetch origin master) \
     && git reset -q --hard $OPAM_HASH \
@@ -21,10 +23,12 @@
  (run (shell "opam pin add -yn ."))
  ; Install OS package dependencies
  (run
+  (network host)
   (cache (opam-archives (target /home/opam/.opam/download-cache)))
   (shell "opam depext -y obuilder"))
  ; Install OCaml dependencies
  (run
+  (network host)
   (cache (opam-archives (target /home/opam/.opam/download-cache)))
   (shell "opam install --deps-only -t obuilder"))
  (copy                                                  ; Copy the rest of the source code

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -12,7 +12,8 @@ type t = {
   user : Obuilder_spec.user;
   env : Os.env;
   mounts : Mount.t list;
+  network : string list;
 }
 
-let v ~cwd ~argv ~hostname ~user ~env ~mounts =
-  { cwd; argv; hostname; user; env; mounts }
+let v ~cwd ~argv ~hostname ~user ~env ~mounts ~network =
+  { cwd; argv; hostname; user; env; mounts; network }

--- a/lib_spec/docker.ml
+++ b/lib_spec/docker.ml
@@ -22,7 +22,7 @@ let of_op ~buildkit (acc, ctx) : Spec.op -> Dockerfile.t list * ctx = function
   | `Comment x -> comment "%s" x :: acc, ctx
   | `Workdir x -> workdir "%s" x :: acc, ctx
   | `Shell xs -> shell xs :: acc, ctx
-  | `Run { cache = (_ :: _) as cache; shell } when buildkit ->
+  | `Run { cache = (_ :: _) as cache; shell; network = _ } when buildkit ->
     let mounts =
       cache |> List.map (fun { Cache.id; target; buildkit_options } ->
           let buildkit_options =
@@ -36,7 +36,7 @@ let of_op ~buildkit (acc, ctx) : Spec.op -> Dockerfile.t list * ctx = function
         )
     in
     run "%s %s" (String.concat " " mounts) (wrap shell) :: acc, ctx
-  | `Run { cache = _; shell } -> run "%s" (wrap shell) :: acc, ctx
+  | `Run { cache = _; network = _; shell } -> run "%s" (wrap shell) :: acc, ctx
   | `Copy { src; dst; exclude = _ } ->
     if ctx.user = Spec.root then copy ~src ~dst () :: acc, ctx
     else (

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -40,11 +40,12 @@ type user = { uid : int; gid : int }
 
 type run = {
   cache : Cache.t list [@sexp.list];
+  network : string list [@sexp.list];
   shell : string;
 } [@@deriving sexp]
 
 let run_inlined = function
-  | "cache" -> true
+  | "cache" | "network" -> true
   | _ -> false
 
 let run_of_sexp x = run_of_sexp (inflate_record run_inlined x)
@@ -108,7 +109,7 @@ let stage_of_sexp = function
 let comment fmt = fmt |> Printf.ksprintf (fun c -> `Comment c)
 let workdir x = `Workdir x
 let shell xs = `Shell xs
-let run ?(cache=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache })
+let run ?(cache=[]) ?(network=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache; network })
 let copy ?(exclude=[]) src ~dst = `Copy { src; dst; exclude }
 let env k v = `Env (k, v)
 let user ~uid ~gid = `User { uid; gid }

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -11,6 +11,7 @@ type user = {
 
 type run = {
   cache : Cache.t list;
+  network : string list;
   shell : string;
 } [@@deriving sexp]
 
@@ -34,7 +35,7 @@ val stage : from:string -> op list -> stage
 val comment : ('a, unit, string, op) format4 -> 'a
 val workdir : string -> op
 val shell : string list -> op
-val run : ?cache:Cache.t list -> ('a, unit, string, op) format4 -> 'a
+val run : ?cache:Cache.t list -> ?network:string list -> ('a, unit, string, op) format4 -> 'a
 val copy : ?exclude:string list -> string list -> dst:string -> op
 val env : string -> string -> op
 val user : uid:int -> gid:int -> op


### PR DESCRIPTION
For now, the only options are `(network host)` (uncontained, as before) and nothing (isolated private network; the new default).