### PR TITLE
Tighten runc policy slightly

### DIFF
--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -156,13 +156,17 @@ module Json_config = struct
             "rbind";
             "rprivate"
           ] ::
-        mount "/etc/resolv.conf"
-          ~ty:"bind"
-          ~src:"/etc/resolv.conf"  (* XXX *)
-          ~options:[
-            "rbind";
-            "rprivate"
-          ] ::
+        (if network = ["host"] then
+           [ mount "/etc/resolv.conf"
+               ~ty:"bind"
+               ~src:"/etc/resolv.conf"
+               ~options:[
+                 "rbind";
+                 "rprivate"
+               ]
+           ]
+         else []
+        ) @
         user_mounts mounts
       );
       "linux", `Assoc [

--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -181,20 +181,6 @@ module Json_config = struct
         user_mounts mounts
       );
       "linux", `Assoc [
-        "uidMappings", `List [
-          `Assoc [
-            "containerID", `Int 0;
-            "hostID", `Int 1000;
-            "size", `Int 1
-          ];
-        ];
-        "gidMappings", `List [
-          `Assoc [
-            "containerID", `Int 0;
-            "hostID", `Int 1000;
-            "size", `Int 1;
-          ];
-        ];
         "namespaces", `List (List.map namespace namespaces);
         "maskedPaths", strings [
           "/proc/acpi";

--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -29,7 +29,7 @@ module Json_config = struct
 
   let namespace x = `Assoc [ "type", `String x ]
 
-  (* This is the same set that Docker uses by default.
+  (* This is a subset of the capabilities that Docker uses by default.
      These control what root can do in the container.
      If the init process is non-root, permitted, effective and ambient sets are cleared.
      See capabilities(7) for full details. *)
@@ -39,15 +39,17 @@ module Json_config = struct
     "CAP_FSETID";               (* Set SUID/SGID bits. *)
     "CAP_FOWNER";               (* Bypass permission checks. *)
     "CAP_MKNOD";                (* Create special files using mknod. *)
-    "CAP_NET_RAW";              (* Use RAW and PACKET sockets / bind to any address *)
     "CAP_SETGID";               (* Make arbitrary manipulations of process GIDs. *)
     "CAP_SETUID";               (* Make arbitrary manipulations of process UIDs. *)
     "CAP_SETFCAP";              (* Set arbitrary capabilities on a file. *)
     "CAP_SETPCAP";              (* Add any capability from bounding set to inheritable set. *)
-    "CAP_NET_BIND_SERVICE";     (* Bind a socket to Internet domain privileged ports. *)
     "CAP_SYS_CHROOT";           (* Use chroot. *)
     "CAP_KILL";                 (* Bypass permission checks for sending signals. *)
     "CAP_AUDIT_WRITE"           (* Write records to kernel auditing log. *)
+    (* Allowed by Docker, but disabled here (because we use host networking):
+    "CAP_NET_RAW";              (* Use RAW and PACKET sockets / bind to any address *)
+    "CAP_NET_BIND_SERVICE";     (* Bind a socket to Internet domain privileged ports. *)
+    *)
   ]
 
   let make {Config.cwd; argv; hostname; user; env; mounts; network} ~config_dir ~results_dir : Yojson.Safe.t =

--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -122,6 +122,25 @@ module Json_config = struct
             "newinstance";
             "ptmxmode=0666";
             "mode=0620";
+            "gid=5";            (* tty *)
+          ] ::
+        mount "/sys"            (* This is how Docker does it. runc's default is a bit different. *)
+          ~ty:"sysfs"
+          ~src:"sysfs"
+          ~options:[
+            "nosuid";
+            "noexec";
+            "nodev";
+            "ro";
+          ] ::
+        mount "/sys/fs/cgroup"
+          ~ty:"cgroup"
+          ~src:"cgroup"
+          ~options:[
+            "ro";
+            "nosuid";
+            "noexec";
+            "nodev";
           ] ::
         mount "/dev/shm"
           ~ty:"tmpfs"
@@ -140,16 +159,6 @@ module Json_config = struct
             "nosuid";
             "noexec";
             "nodev";
-          ] ::
-        mount "/sys"
-          ~ty:"none"
-          ~src:"/sys"
-          ~options:[
-            "rbind";
-            "nosuid";
-            "noexec";
-            "nodev";
-            "ro";
           ] ::
         mount "/etc/hosts"
           ~ty:"bind"


### PR DESCRIPTION
- Document Linux capabilities
- Only share host resolv.conf if container uses host networking
- Remove CAP_NET_RAW and CAP_NET_BIND_SERVICE
- Make runc mounts configuration more like Docker's configuration
- Remove rootless runc options