### PR TITLE
Fix copying of a single file to a directory

### DIFF
--- a/lib/tar_transfer.mli
+++ b/lib/tar_transfer.mli
@@ -1,11 +1,23 @@
 val send_files :
   src_dir:string ->
-  src_manifest:Manifest.t list ->        (* Better name? *)
+  src_manifest:Manifest.t list ->
+  dst_dir:string ->
+  user:Obuilder_spec.user ->
+  to_untar:Lwt_unix.file_descr ->
+  unit Lwt.t
+(** [send_files ~src_dir ~src_manifest ~dst_dir ~user ~to_untar] writes a tar-format stream
+    to [to_untar] containing all the files listed in [src_manifest], which are
+    loaded from [src_dir]. The file names in the stream are prefixed with [dst_dir].
+    All files are listed as being owned by [user]. *)
+
+val send_file :
+  src_dir:string ->
+  src_manifest:Manifest.t ->
   dst:string ->
   user:Obuilder_spec.user ->
   to_untar:Lwt_unix.file_descr ->
   unit Lwt.t
 (** [send_files ~src_dir ~src_manifest ~dst ~user ~to_untar] writes a tar-format stream
-    to [to_untar] containing all the files listed in [src_manifest], which are
-    loaded from [src_dir]. The file names in the stream are prefixed with [dst].
+    to [to_untar] containing the item [src_manifest], which is loaded from
+    [src_dir]. The item will be copied as [dst].
     All files are listed as being owned by [user]. *)


### PR DESCRIPTION
We should only treat `dst` as a directory if it ends with `/`. We only applied this rule for directories, but it should also apply to files and symlinks.