### PR TITLE
Improve formatting of OBuilder specs

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -142,8 +142,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
         )
 
   let pp_op ~(context:Context.t) f op =
-    let sexp = Obuilder_spec.sexp_of_op op in
-    Fmt.pf f "@[<v2>%s: %a@]" context.workdir Sexplib.Sexp.pp_hum sexp
+    Fmt.pf f "@[<v2>%s: %a@]" context.workdir Obuilder_spec.pp_op op
 
   let update_workdir ~(context:Context.t) path =
     let workdir =
@@ -198,7 +197,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
       (fun () -> Os.exec ["docker"; "rm"; "--"; cid])
 
   let get_base t ~log base =
-    log `Heading (Fmt.strf "FROM %s" base);
+    log `Heading (Fmt.strf "(from %a)" Sexplib.Sexp.pp_hum (Atom base));
     let id = Sha256.to_hex (Sha256.string base) in
     Store.build t.store ~id ~log (fun ~cancelled:_ ~log:_ tmp ->
         Log.info (fun f -> f "Base image not present; importing %S...@." base);

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -41,3 +41,11 @@ val env : string -> string -> op
 val user : uid:int -> gid:int -> op
 
 val root : user
+
+val pp_stage : stage Fmt.t
+(** [pp_stage f s] is similar to [Sexplib.Sexp.pp_hum f (sexp_of_stage s)], but
+    attempts to improve the layout slightly by putting each operation on its
+    own line. *)
+
+val pp_op : op Fmt.t
+(** [pp_op] formats [op] as an S-expression. *)


### PR DESCRIPTION
Before:

```sexp
((from
  ocaml/opam@sha256:b2245cea39ed16fd39bd7ab70204b28fb73d1364e1bc702ef495798349e55e4f)
 (comment debian-10-4.10) (user (uid 1000) (gid 1000))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam install dune.2.7.1"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host)
  (shell
   "opam pin add -n https://github.com/ocamllabs/duniverse.git#6b6c1b8173afab88933762f6b5ee82a070b2d715"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam depext --update -y opam-monorepo"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam install opam-monorepo"))
 (workdir /src) (run (shell "sudo chown opam /src"))
 (copy (src dune-project rwo.opam rwo.opam.locked) (dst /src/))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam pin -n add rwo . --locked"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam depext --update -y rwo"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam pin remove rwo"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host) (shell "opam exec -- opam monorepo pull"))
 (copy (src .) (dst /src/))
 (run
  (cache
   (dune:realworldocaml:book (target /src/_build)
    (buildkit_options ((sharing private)))))
  (shell "opam exec -- dune build @install"))
 (run
  (cache
   (dune:realworldocaml:book (target /src/_build)
    (buildkit_options ((sharing private)))))
  (shell "opam exec -- dune runtest")))
```

After:
```sexp
((from ocaml/opam@sha256:b2245cea39ed16fd39bd7ab70204b28fb73d1364e1bc702ef495798349e55e4f)
 (comment debian-10-4.10)
 (user (uid 1000) (gid 1000))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam install dune.2.7.1"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam pin add -n https://github.com/ocamllabs/duniverse.git#6b6c1b8173afab88933762f6b5ee82a070b2d715"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam depext --update -y opam-monorepo"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam install opam-monorepo"))
 (workdir /src)
 (run (shell "sudo chown opam /src"))
 (copy (src dune-project rwo.opam rwo.opam.locked) (dst /src/))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam pin -n add rwo . --locked"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam depext --update -y rwo"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam pin remove rwo"))
 (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
      (network host)
      (shell "opam exec -- opam monorepo pull"))
 (copy (src .) (dst /src/))
 (run (cache (dune:realworldocaml:book (target /src/_build) (buildkit_options ((sharing private)))))
      (shell "opam exec -- dune build @install"))
 (run (cache (dune:realworldocaml:book (target /src/_build) (buildkit_options ((sharing private)))))
      (shell "opam exec -- dune runtest"))
)
```