### PR TITLE
Clean up left-over runc containers on restart

### DIFF
--- a/lib/runc_sandbox.mli
+++ b/lib/runc_sandbox.mli
@@ -1,6 +1,6 @@
 include S.SANDBOX
 
-val create : ?fast_sync:bool -> runc_state_dir:string -> unit -> t
+val create : ?fast_sync:bool -> runc_state_dir:string -> unit -> t Lwt.t
 (** [create dir] is a runc sandboxing system that keeps state in [dir].
     @param fast_sync Use seccomp to skip all sync syscalls. This is fast (and
                      safe, since we discard builds after a crash), but requires

--- a/main.ml
+++ b/main.ml
@@ -21,9 +21,9 @@ let log tag msg =
   | `Output -> output_string stdout msg; flush stdout
 
 let create_builder ?fast_sync spec =
-  Obuilder.Store_spec.to_store spec >|= fun (Store ((module Store), store)) -> 
+  Obuilder.Store_spec.to_store spec >>= fun (Store ((module Store), store)) -> 
   let module Builder = Obuilder.Builder(Store)(Sandbox) in
-  let sandbox = Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") ?fast_sync () in
+  Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") ?fast_sync () >|= fun sandbox ->
   let builder = Builder.v ~store ~sandbox in
   Builder ((module Builder), builder)
 

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -155,7 +155,7 @@ module Test(Store : S.STORE) = struct
     | Error `Cancelled -> assert false
 
   let stress_builds store =
-    let sandbox = Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") ~fast_sync:true () in
+    Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") ~fast_sync:true () >>= fun sandbox ->
     let builder = Build.v ~store ~sandbox in
     let pending = ref n_jobs in
     let running = ref 0 in
@@ -194,7 +194,7 @@ module Test(Store : S.STORE) = struct
     else Lwt.return_unit
 
   let prune store =
-    let sandbox = Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") () in
+    Sandbox.create ~runc_state_dir:(Store.state_dir store / "runc") () >>= fun sandbox ->
     let builder = Build.v ~store ~sandbox in
     let log id = Logs.info (fun f -> f "Deleting %S" id) in
     let end_time = Unix.(gettimeofday () +. 60.0 |> gmtime) in


### PR DESCRIPTION
If btrfs crashes and makes the FS read-only then after rebooting there will be stale runc directories. New jobs with the same IDs will then fail.