### PR TITLE
Increase healthcheck timeout

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -292,7 +292,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     | `Heading | `Note -> Buffer.add_string buffer (x ^ "\n")
     | `Output -> Buffer.add_string buffer x
 
-  let healthcheck ?(timeout=10.0) t =
+  let healthcheck ?(timeout=30.0) t =
     Os.with_pipe_from_child (fun ~r ~w ->
         let pp f = Fmt.string f "docker version" in
         let result = Os.exec_result ~pp ~stdout:`Dev_null ~stderr:(`FD_move_safely w) ["docker"; "version"] in


### PR DESCRIPTION
In testing, a moderately busy 48-core machine with a load of 27 took longer than 10s.