### PR TITLE
runc_sandbox: allow handling stdout/stderr separately

### DIFF
--- a/lib/s.ml
+++ b/lib/s.ml
@@ -64,10 +64,16 @@ end
 module type SANDBOX = sig
   type t
 
+  type output_source = [ `Stdout | `Stderr ]
+  
+  type log_function = string -> unit Lwt.t
+
+  type log_handler = [ `Merged of log_function | `Tagged of output_source -> log_function ]
+
   val run :
     cancelled:unit Lwt.t ->
     ?stdin:Os.unix_fd ->
-    log:Build_log.t ->
+    log:log_handler ->
     t ->
     Config.t ->
     string ->


### PR DESCRIPTION
When using runc for nix builds, I needed the ability to separate stdout from stderr (since build logs go to stderr, and we want to separately capture stdout for further processing). I also had no use for a proper `Build_log`, since I'm just streaming the nix logs directly to the ocluster build output.

The approach here is pretty minimal so it doesn't impact other usage which sticks with the ``Merged` stream.

It's not brilliant though, since the user of a `Tagged` stream likely wants to process the stream linewise to prevent interleaved lines. I haven't done that in my callsite yet, and if it's going to be done maybe it makes sense to do here instead?

For context, here's the `Tagged` use case for building nix derivations:

https://github.com/ocurrent/ocluster/blob/2dc9f7a5dce1778b54a9101b49107556f1653dcb/worker/nix_build.ml#L18-L42

(from PR: https://github.com/ocurrent/ocluster/pull/112 )