### PR TITLE
Allow to bind tmpfs to a custom path bound to each run

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -20,7 +20,8 @@ type t = {
   env : env;
   mounts : Mount.t list;
   network : string list;
+  tmpfs : string list;
 }
 
-let v ~cwd ~argv ~hostname ~user ~env ~mounts ~network =
-  { cwd; argv; hostname; user; env; mounts; network }
+let v ~cwd ~argv ~hostname ~user ~env ~mounts ~network ~tmpfs =
+  { cwd; argv; hostname; user; env; mounts; network; tmpfs }

--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -99,7 +99,7 @@ module Json_config = struct
     in
     `Assoc fields
 
-  let make {Config.cwd; argv; hostname; user; env; mounts; network} t ~config_dir ~results_dir : Yojson.Safe.t =
+  let make {Config.cwd; argv; hostname; user; env; mounts; network; tmpfs} t ~config_dir ~results_dir : Yojson.Safe.t =
     let user =
       let { Obuilder_spec.uid; gid } = user in
       `Assoc [
@@ -225,6 +225,14 @@ module Json_config = struct
            ]
          else []
         ) @
+        List.map (fun target ->
+          mount target
+            ~ty:"tmpfs"
+            ~src:"tmpfs"
+            ~options:[
+              "size=6G";
+            ]
+        ) tmpfs @
         user_mounts mounts
       );
       "linux", `Assoc [
@@ -251,7 +259,7 @@ module Json_config = struct
         "seccomp", seccomp_policy t;
       ];
     ]
-end  
+end
 
 let next_id = ref 0
 

--- a/lib_spec/docker.ml
+++ b/lib_spec/docker.ml
@@ -24,8 +24,11 @@ let pp_cache ~ctx f { Cache.id; target; buildkit_options } =
   in
   Fmt.pf f "%a" Fmt.(list ~sep:(unit ",") pp_pair) buildkit_options
 
-let pp_run ~ctx f { Spec.cache; shell; network = _ } =
-  Fmt.pf f "RUN %a%a" Fmt.(list (pp_cache ~ctx ++ const string " ")) cache pp_wrap shell
+let pp_tmpfs f target =
+  Fmt.pf f "--mount=type=tmpfs,target=%s" target
+
+let pp_run ~ctx f { Spec.cache; shell; network = _; tmpfs } =
+  Fmt.pf f "RUN %a%a%a" Fmt.(list (pp_cache ~ctx ++ const string " ")) cache (Fmt.list pp_tmpfs) tmpfs pp_wrap shell
 
 let pp_copy ~ctx f { Spec.from; src; dst; exclude = _ } =
   let from = match from with

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -62,11 +62,12 @@ type user = { uid : int; gid : int }
 type run = {
   cache : Cache.t list [@sexp.list];
   network : string list [@sexp.list];
+  tmpfs : string list [@sexp.list];
   shell : string;
 } [@@deriving sexp]
 
 let run_inlined = function
-  | "cache" | "network" -> true
+  | "cache" | "network" | "tmpfs" -> true
   | _ -> false
 
 let run_of_sexp x = run_of_sexp (inflate_record run_inlined x)
@@ -145,7 +146,7 @@ let rec t_of_sexp = function
 let comment fmt = fmt |> Printf.ksprintf (fun c -> `Comment c)
 let workdir x = `Workdir x
 let shell xs = `Shell xs
-let run ?(cache=[]) ?(network=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache; network })
+let run ?(cache=[]) ?(network=[]) ?(tmpfs=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache; network; tmpfs })
 let copy ?(from=`Context) ?(exclude=[]) src ~dst = `Copy { from; src; dst; exclude }
 let env k v = `Env (k, v)
 let user ~uid ~gid = `User { uid; gid }

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -13,6 +13,7 @@ type user = {
 type run = {
   cache : Cache.t list;
   network : string list;
+  tmpfs : string list;
   shell : string;
 } [@@deriving sexp]
 
@@ -37,7 +38,7 @@ val stage : ?child_builds:(string * t) list -> from:string -> op list -> t
 val comment : ('a, unit, string, op) format4 -> 'a
 val workdir : string -> op
 val shell : string list -> op
-val run : ?cache:Cache.t list -> ?network:string list -> ('a, unit, string, op) format4 -> 'a
+val run : ?cache:Cache.t list -> ?network:string list -> ?tmpfs:string list -> ('a, unit, string, op) format4 -> 'a
 val copy : ?from:[`Context | `Build of string] -> ?exclude:string list -> string list -> dst:string -> op
 val env : string -> string -> op
 val user : uid:int -> gid:int -> op


### PR DESCRIPTION
Implement the new `(tmpfs ...)` option suggested in https://github.com/ocaml/opam/issues/4586#issuecomment-792652719