### PR TITLE
Add support for secrets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### unreleased
+
+- Add support for secrets (@TheLortex #63, reviewed by @talex5).
+  The obuilder spec's `run` command supports a new `secrets` fields, which allows to temporarily
+  mount secret files in an user-specified location. The sandbox build context has an additional
+  `secrets` parameter to provide values for the requested keys.
+
 ### v0.3
 
 Security fix:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The command run will be this list of arguments followed by the single argument `
 (run
  (cache CACHE...)?
  (network NETWORK...)?
+ (secrets SECRET...)?
  (shell COMMAND))
  
 ```
@@ -176,6 +177,7 @@ Examples:
 (run
  (cache (opam-archives (target /home/opam/.opam/download-cache)))
  (network host)
+ (secrets (password (target /secrets/password)))
  (shell "opam install utop"))
 ```
 
@@ -197,6 +199,15 @@ Otherwise, a fresh network namespace is created for the container, with interfac
 networks (if any).
 
 Currently, no other networks can be used, so the only options are `host` or an isolated private network.
+
+The `(secrets SECRET...)` field can be used to request values for chosen keys, mounted as read-only files in 
+the image. Each `SECRET` entry is under the form `(KEY (target PATH))`, where `KEY` is the secret key, and 
+`PATH` is the location of the mounted secret file within the container.
+The sandbox context API contains a `secrets` parameter to provide values to the runtime. If a requested key
+isn't provided with a value, the runtime fails.
+With the command line interface `obuilder`, use the `--secret KEY=VALUE` option to provide values.
+When used with Docker, make sure to use the **buildkit** syntax, as only buildkit supports a `--secret` option.
+(See https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information)
 
 ### copy
 
@@ -289,7 +300,7 @@ The dockerfile should work the same way as the spec file, except for these limit
 - In `(copy (excludes ...) ...)` the excludes part is ignored.
   You will need to ensure you have a suitable `.dockerignore` file instead.
 
-- If you want to include caches, use `--buildkit` to output in the extended BuildKit syntax.
+- If you want to include caches or to use secrets, use `--buildkit` to output in the extended BuildKit syntax.
 
 - All `(network ...)` fields are ignored, as Docker does not allow per-step control of
   networking.

--- a/README.md
+++ b/README.md
@@ -201,11 +201,12 @@ networks (if any).
 Currently, no other networks can be used, so the only options are `host` or an isolated private network.
 
 The `(secrets SECRET...)` field can be used to request values for chosen keys, mounted as read-only files in 
-the image. Each `SECRET` entry is under the form `(KEY (target PATH))`, where `KEY` is the secret key, and 
+the image. Each `SECRET` entry is under the form `(ID (target PATH))`, where `ID` selects the secret, and 
 `PATH` is the location of the mounted secret file within the container.
-The sandbox context API contains a `secrets` parameter to provide values to the runtime. If a requested key
-isn't provided with a value, the runtime fails.
-With the command line interface `obuilder`, use the `--secret KEY=VALUE` option to provide values.
+The sandbox context API contains a `secrets` parameter to provide values to the runtime.
+If a requested secret isn't provided with a value, the runtime fails.
+With the command line interface `obuilder`, use the `--secret ID:PATH` option to provide the path of the file
+containing the secret for `ID`.
 When used with Docker, make sure to use the **buildkit** syntax, as only buildkit supports a `--secret` option.
 (See https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information)
 

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -60,7 +60,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     cmd : string;
     shell : string list;
     network : string list;
-    mount_secrets : (string * string * string) list; (* key * value * target *)
+    mount_secrets : Config.Secret.t list;
   } [@@deriving sexp_of]
 
   let run t ~switch ~log ~cache run_input =
@@ -184,7 +184,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
   let mount_secret (values : (string * string) list) (key: Obuilder_spec.Secret.t) =
     match List.assoc_opt key.id values with
     | None -> Error (`Msg ("Couldn't find value for requested secret '"^key.id^"'") )
-    | Some value -> Ok (key.id, value, key.target)
+    | Some value -> Ok Config.Secret.{value; target=key.target}
 
   let resolve_secrets (values : (string * string) list) (keys: Obuilder_spec.Secret.t list) =
     let (>>=) = Result.bind in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -182,9 +182,9 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     { context with workdir }
 
   let mount_secret (values : (string * string) list) (key: Obuilder_spec.Secret.t) =
-    match List.find_opt (fun (k, _) -> key.id = k) values with
+    match List.assoc_opt key.id values with
     | None -> Error (`Msg ("Couldn't find value for requested secret '"^key.id^"'") )
-    | Some (_, value) -> Ok (key.id, value, key.target)
+    | Some value -> Ok (key.id, value, key.target)
 
   let resolve_secrets (values : (string * string) list) (keys: Obuilder_spec.Secret.t list) =
     let (>>=) = Result.bind in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -181,18 +181,18 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     in
     { context with workdir }
 
-  let mount_secret (values : (string * string) list) (key: Obuilder_spec.Secret.t) =
-    match List.assoc_opt key.id values with
-    | None -> Error (`Msg ("Couldn't find value for requested secret '"^key.id^"'") )
-    | Some value -> Ok Config.Secret.{value; target=key.target}
+  let mount_secret (values : (string * string) list) (secret: Obuilder_spec.Secret.t) =
+    match List.assoc_opt secret.id values with
+    | None -> Error (`Msg ("Couldn't find value for requested secret '"^secret.id^"'") )
+    | Some value -> Ok Config.Secret.{value; target=secret.target}
 
-  let resolve_secrets (values : (string * string) list) (keys: Obuilder_spec.Secret.t list) =
+  let resolve_secrets (values : (string * string) list) (secrets: Obuilder_spec.Secret.t list) =
     let (>>=) = Result.bind in
     let (>>|) x y = Result.map y x in
     List.fold_left (fun result secret ->
       result >>= fun result ->
       mount_secret values secret >>| fun resolved_secret ->
-      (resolved_secret :: result) ) (Ok []) keys
+      (resolved_secret :: result) ) (Ok []) secrets
 
   let rec run_steps t ~(context:Context.t) ~base = function
     | [] -> Lwt_result.return base

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -26,10 +26,11 @@ module Context = struct
     shell : string list;
     log : S.logger;
     scope : string Scope.t;             (* Nested builds that are in scope. *)
+    secrets : (string * string) list;
   }
 
-  let v ?switch ?(env=[]) ?(user=Obuilder_spec.root) ?(workdir="/") ?(shell=["/bin/bash"; "-c"]) ~log ~src_dir () =
-    { switch; env; src_dir; user; workdir; shell; log; scope = Scope.empty }
+  let v ?switch ?(env=[]) ?(user=Obuilder_spec.root) ?(workdir="/") ?(shell=["/bin/bash"; "-c"]) ?(secrets=[]) ~log ~src_dir () =
+    { switch; env; src_dir; user; workdir; shell; log; scope = Scope.empty; secrets }
 
   let with_binding name value t =
     { t with scope = Scope.add name value t.scope }
@@ -59,6 +60,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     cmd : string;
     shell : string list;
     network : string list;
+    mount_secrets : (string * string * string) list; (* key * value * target *)
   } [@@deriving sexp_of]
 
   let run t ~switch ~log ~cache run_input =
@@ -68,7 +70,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
       |> Sha256.string
       |> Sha256.to_hex
     in
-    let { base; workdir; user; env; cmd; shell; network } = run_input in
+    let { base; workdir; user; env; cmd; shell; network; mount_secrets } = run_input in
     Store.build t.store ?switch ~base ~id ~log (fun ~cancelled ~log result_tmp ->
         let to_release = ref [] in
         Lwt.finalize
@@ -80,7 +82,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
                )
              >>= fun mounts ->
              let argv = shell @ [cmd] in
-             let config = Config.v ~cwd:workdir ~argv ~hostname ~user ~env ~mounts ~network in
+             let config = Config.v ~cwd:workdir ~argv ~hostname ~user ~env ~mounts ~mount_secrets ~network in
              Os.with_pipe_to_child @@ fun ~r:stdin ~w:close_me ->
              Lwt_unix.close close_me >>= fun () ->
              Sandbox.run ~cancelled ~stdin ~log t.sandbox config result_tmp
@@ -111,7 +113,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     | _ -> Fmt.error_msg "When copying multiple items, the destination must end with '/'"
 
   let copy t ~context ~base { Obuilder_spec.from; src; dst; exclude } =
-    let { Context.switch; src_dir; workdir; user; log; shell = _; env = _; scope } = context in
+    let { Context.switch; src_dir; workdir; user; log; shell = _; env = _; scope; secrets = _ } = context in
     let dst = if Filename.is_relative dst then workdir / dst else dst in
     begin
       match from with
@@ -145,6 +147,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
               ~hostname
               ~user:Obuilder_spec.root
               ~env:["PATH", "/bin:/usr/bin"]
+              ~mount_secrets:[]
               ~mounts:[]
               ~network:[]
           in
@@ -178,6 +181,19 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
     in
     { context with workdir }
 
+  let mount_secret (values : (string * string) list) (key: Obuilder_spec.Secret.t) =
+    match List.find_opt (fun (k, _) -> key.id = k) values with
+    | None -> Error (`Msg ("Couldn't find value for requested secret '"^key.id^"'") )
+    | Some (_, value) -> Ok (key.id, value, key.target)
+
+  let resolve_secrets (values : (string * string) list) (keys: Obuilder_spec.Secret.t list) =
+    let (>>=) = Result.bind in
+    let (>>|) x y = Result.map y x in
+    List.fold_left (fun result secret ->
+      result >>= fun result ->
+      mount_secret values secret >>| fun resolved_secret ->
+      (resolved_secret :: result) ) (Ok []) keys
+
   let rec run_steps t ~(context:Context.t) ~base = function
     | [] -> Lwt_result.return base
     | op :: ops ->
@@ -187,11 +203,13 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
       | `Comment _ -> k ~base ~context
       | `Workdir workdir -> k ~base ~context:(update_workdir ~context workdir)
       | `User user -> k ~base ~context:{context with user}
-      | `Run { shell = cmd; cache; network } ->
-        let switch, run_input, log =
-          let { Context.switch; workdir; user; env; shell; log; src_dir = _; scope = _ } = context in
-          (switch, { base; workdir; user; env; cmd; shell; network }, log)
+      | `Run { shell = cmd; cache; network; secrets= mount_secrets } ->
+        let result =
+          let { Context.switch; workdir; user; env; shell; log; src_dir = _; scope = _; secrets } = context in
+          resolve_secrets secrets mount_secrets |> Result.map @@ fun mount_secrets ->
+          (switch, { base; workdir; user; env; cmd; shell; network; mount_secrets }, log)
         in
+        Lwt.return result >>!= fun (switch, run_input, log) ->
         run t ~switch ~log ~cache run_input >>!= fun base ->
         k ~base ~context
       | `Copy x ->

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -203,7 +203,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) = struct
       | `Comment _ -> k ~base ~context
       | `Workdir workdir -> k ~base ~context:(update_workdir ~context workdir)
       | `User user -> k ~base ~context:{context with user}
-      | `Run { shell = cmd; cache; network; secrets= mount_secrets } ->
+      | `Run { shell = cmd; cache; network; secrets = mount_secrets } ->
         let result =
           let { Context.switch; workdir; user; env; shell; log; src_dir = _; scope = _; secrets } = context in
           resolve_secrets secrets mount_secrets |> Result.map @@ fun mount_secrets ->

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -7,6 +7,7 @@ module Context : sig
     ?user:Obuilder_spec.user ->
     ?workdir:string ->
     ?shell:string list ->
+    ?secrets:(string * string) list ->
     log:S.logger ->
     src_dir:string ->
     unit -> t
@@ -16,6 +17,7 @@ module Context : sig
       @param user Container user to run as.
       @param workdir Directory in the container namespace for cwd.
       @param shell The command used to run shell commands (default [["/bin/bash"; "-c"]]).
+      @param secrets Provided key-value pairs for secrets.
       @param log Function to receive log data.
   *)
 end

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -12,6 +12,13 @@ module Mount = struct
   }
 end
 
+module Secret = struct
+  type t = {
+    value: string;
+    target: string;
+  } [@@deriving sexp]
+end
+
 type t = {
   cwd : string;
   argv : string list;
@@ -20,7 +27,7 @@ type t = {
   env : env;
   mounts : Mount.t list;
   network : string list;
-  mount_secrets : (string * string * string) list; (* key, value, target *)
+  mount_secrets : Secret.t list;
 }
 
 let v ~cwd ~argv ~hostname ~user ~env ~mounts ~network ~mount_secrets =

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -20,7 +20,8 @@ type t = {
   env : env;
   mounts : Mount.t list;
   network : string list;
+  mount_secrets : (string * string * string) list; (* key, value, target *)
 }
 
-let v ~cwd ~argv ~hostname ~user ~env ~mounts ~network =
-  { cwd; argv; hostname; user; env; mounts; network }
+let v ~cwd ~argv ~hostname ~user ~env ~mounts ~network ~mount_secrets =
+  { cwd; argv; hostname; user; env; mounts; network; mount_secrets }

--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -233,7 +233,8 @@ module Json_config = struct
             ~src:(config_dir / "secret-" ^ key)
             ~options:[
               "rbind";
-              "rprivate"
+              "rprivate";
+              "ro";
             ]
         ) mount_secrets
          @

--- a/lib_spec/obuilder_spec.ml
+++ b/lib_spec/obuilder_spec.ml
@@ -1,4 +1,5 @@
 include Spec
 
 module Cache = Cache
+module Secret = Secret
 module Docker = Docker

--- a/lib_spec/secret.ml
+++ b/lib_spec/secret.ml
@@ -1,0 +1,22 @@
+open Sexplib.Std
+open Sexplib.Sexp
+
+type t = {
+  id : string;
+  target : string;
+  buildkit_options : (string * string) list [@sexp.list];
+} [@@deriving sexp]
+
+let t_of_sexp x =
+  match x with
+  | List (Atom id :: fields) -> t_of_sexp (List (List [Atom "id"; Atom id] :: fields))
+  | x -> Fmt.failwith "Invalid secret: %a" Sexplib.Sexp.pp_hum x
+
+let sexp_of_t x =
+  match sexp_of_t x with
+  | List (List [Atom "id"; Atom id] :: fields) -> List (Atom id :: fields)
+  | x -> Fmt.failwith "Invalid secret: %a" Sexplib.Sexp.pp_hum x
+
+let v ?(buildkit_options=[]) ?target id =
+  let target = Option.value target ~default:("/run/secrets/"^id) in
+  { id; target; buildkit_options }

--- a/lib_spec/secret.mli
+++ b/lib_spec/secret.mli
@@ -1,0 +1,8 @@
+type t = {
+  id : string;
+  target : string;
+  buildkit_options : (string * string) list;        (* Only used when converting to Docker BuildKit format. *)
+} [@@deriving sexp]
+
+val v : ?buildkit_options:(string * string) list -> ?target:string -> string -> t
+(** [v ~target id] mounts secret [id] at [target]. Default target is /run/secrets/[id]. *)

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -67,7 +67,7 @@ type run = {
 } [@@deriving sexp]
 
 let run_inlined = function
-  | "cache" | "network" -> true
+  | "cache" | "network" | "secrets" -> true
   | _ -> false
 
 let run_of_sexp x = run_of_sexp (inflate_record run_inlined x)

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -62,6 +62,7 @@ type user = { uid : int; gid : int }
 type run = {
   cache : Cache.t list [@sexp.list];
   network : string list [@sexp.list];
+  secrets : Secret.t list [@sexp.list];
   shell : string;
 } [@@deriving sexp]
 
@@ -145,7 +146,7 @@ let rec t_of_sexp = function
 let comment fmt = fmt |> Printf.ksprintf (fun c -> `Comment c)
 let workdir x = `Workdir x
 let shell xs = `Shell xs
-let run ?(cache=[]) ?(network=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache; network })
+let run ?(cache=[]) ?(network=[]) ?(secrets=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache; network; secrets })
 let copy ?(from=`Context) ?(exclude=[]) src ~dst = `Copy { from; src; dst; exclude }
 let env k v = `Env (k, v)
 let user ~uid ~gid = `User { uid; gid }

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -13,6 +13,7 @@ type user = {
 type run = {
   cache : Cache.t list;
   network : string list;
+  secrets : Secret.t list;
   shell : string;
 } [@@deriving sexp]
 
@@ -37,7 +38,7 @@ val stage : ?child_builds:(string * t) list -> from:string -> op list -> t
 val comment : ('a, unit, string, op) format4 -> 'a
 val workdir : string -> op
 val shell : string list -> op
-val run : ?cache:Cache.t list -> ?network:string list -> ('a, unit, string, op) format4 -> 'a
+val run : ?cache:Cache.t list -> ?network:string list -> ?secrets:Secret.t list -> ('a, unit, string, op) format4 -> 'a
 val copy : ?from:[`Context | `Build of string] -> ?exclude:string list -> string list -> dst:string -> op
 val env : string -> string -> op
 val user : uid:int -> gid:int -> op

--- a/test/test.ml
+++ b/test/test.ml
@@ -537,6 +537,22 @@ let test_docker () =
               (run (shell "make tools"))))
       (from base)
       (copy (from (build tools)) (src binary) (dst /usr/local/bin/))
+     ) |};
+  test ~buildkit:true "Secrets"
+    {| FROM base as tools
+       RUN make tools
+
+       FROM base
+       RUN --mount=type=secret,id=a,target=/secrets/a,uid=0 --mount=type=secret,id=b,target=/secrets/b,uid=0 command1
+    |} {|
+     ((build tools
+            ((from base)
+             (run (shell "make tools"))))
+      (from base)
+      (run
+       (secrets (a (target /secrets/a))
+                (b (target /secrets/b)))
+       (shell "command1"))
      ) |}
 
 let manifest =

--- a/test/test.ml
+++ b/test/test.ml
@@ -451,6 +451,7 @@ let test_sexp () =
       (workdir /src)
       (run (shell "a command"))
       (run (cache (a (target /data)) (b (target /srv)))
+           (secrets (a (target /run/secrets/a)) (b (target /b)))
            (shell "a very very very very very very very very very very very very very very very long command"))
       (copy (src a b) (dst c))
       (copy (src a b) (dst c) (exclude .git _build))

--- a/test/test.ml
+++ b/test/test.ml
@@ -63,7 +63,7 @@ let test_simple _switch () =
   Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
   B.build builder context spec >>!= get store "output" >>= fun result ->
   Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> saved as .*
       /: (run (shell Append))
@@ -92,7 +92,7 @@ let test_prune _switch () =
   Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
   B.build builder context spec >>!= get store "output" >>= fun result ->
   Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> saved as .*
       /: (run (shell Append))
@@ -130,7 +130,7 @@ let test_concurrent _switch () =
   b2 >>!= get store "output" >>= fun b2 ->
   Alcotest.(check build_result) "Final result" (Ok "AB") b1;
   Alcotest.(check build_result) "Final result" (Ok "AC") b2;
-  Log.check "Check AB log" 
+  Log.check "Check AB log"
     {| (from base)
       ;---> saved as .*
        /: (run (shell A))
@@ -141,7 +141,7 @@ let test_concurrent _switch () =
       ;---> saved as .*
      |}
     log1;
-  Log.check "Check AC log" 
+  Log.check "Check AC log"
     {| (from base)
       ;---> using .* from cache
        /: (run (shell A))
@@ -174,14 +174,14 @@ let test_concurrent_failure _switch () =
   b2 >>!= get store "output" >>= fun b2 ->
   Alcotest.(check build_result) "B1 result" (Error (`Msg "Mock build failure")) b1;
   Alcotest.(check build_result) "B2 result" (Error (`Msg "Mock build failure")) b2;
-  Log.check "Check AB log" 
+  Log.check "Check AB log"
     {| (from base)
       ;---> saved as .*
        /: (run (shell A))
        A
      |}
     log1;
-  Log.check "Check AC log" 
+  Log.check "Check AC log"
     {| (from base)
       ;---> using .* from cache
        /: (run (shell A))
@@ -211,14 +211,14 @@ let test_concurrent_failure_2 _switch () =
   b2 >>!= get store "output" >>= fun b2 ->
   Alcotest.(check build_result) "B1 result" (Error (`Msg "Mock build failure")) b1;
   Alcotest.(check build_result) "B2 result" (Error (`Msg "Mock build failure")) b2;
-  Log.check "Check AB log" 
+  Log.check "Check AB log"
     {| (from base)
       ;---> saved as .*
        /: (run (shell A))
        A
      |}
     log1;
-  Log.check "Check AC log" 
+  Log.check "Check AC log"
     {| (from base)
       ;---> using .* from cache
        /: (run (shell A))
@@ -240,7 +240,7 @@ let test_cancel _switch () =
   Lwt_switch.turn_off switch >>= fun () ->
   b >>= fun result ->
   Alcotest.(check build_result) "Final result" (Error `Cancelled) result;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> saved as .*
       /: (run (shell Wait))
@@ -267,7 +267,7 @@ let test_cancel_2 _switch () =
   Lwt_switch.turn_off switch1 >>= fun () ->
   b1 >>= fun result1 ->
   Alcotest.(check build_result) "User 1 result" (Error `Cancelled) result1;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> saved as .*
       /: (run (shell Wait))
@@ -276,7 +276,7 @@ let test_cancel_2 _switch () =
   Lwt.wakeup set_r (Ok ());
   b2 >>!= get store "output" >>= fun result2 ->
   Alcotest.(check build_result) "Final result" (Ok "ok") result2;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> using .* from cache
       /: (run (shell Wait))
@@ -304,7 +304,7 @@ let test_cancel_3 _switch () =
   Lwt_switch.turn_off switch1 >>= fun () ->
   b1 >>= fun result1 ->
   Alcotest.(check build_result) "User 1 result" (Error `Cancelled) result1;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> saved as .*
       /: (run (shell Wait))
@@ -313,7 +313,7 @@ let test_cancel_3 _switch () =
   Lwt_switch.turn_off switch2 >>= fun () ->
   b2 >>!= get store "output" >>= fun result2 ->
   Alcotest.(check build_result) "User 2 result" (Error `Cancelled) result2;
-  Log.check "Check log" 
+  Log.check "Check log"
     {|(from base)
       ;---> using .* from cache
       /: (run (shell Wait))
@@ -602,6 +602,35 @@ let test_cache_id () =
   check "c-foo%3abar" "foo:bar";
   check "c-Az09-id.foo_orig" "Az09-id.foo_orig"
 
+  let test_secrets_not_provided _switch () =
+    with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+    let log = Log.create "b" in
+    let context = Context.v ~src_dir ~log:(Log.add log) () in
+    let spec = Spec.(stage ~from:"base" [ run ~secrets:[Secret.v ~target:"/run/secrets/test" "test"] "Append" ]) in
+    Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
+    B.build builder context spec >>!= get store "output" >>= fun result ->
+    Alcotest.(check build_result) "Final result" (Error (`Msg "Couldn't find value for requested secret 'test'")) result;
+    Lwt.return_unit
+
+  let test_secrets_simple _switch () =
+    with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+    let log = Log.create "b" in
+    let context = Context.v ~src_dir ~log:(Log.add log) ~secrets:["test", "top secret value"] () in
+    let spec = Spec.(stage ~from:"base" [ run ~secrets:[Secret.v ~target:"/run/secrets/test" "test"] "Append" ]) in
+    Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
+    B.build builder context spec >>!= get store "output" >>= fun result ->
+    Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
+    Log.check "Check b log"
+      {| (from base)
+        ;---> saved as .*
+         /: (run (secrets ((test (target /run/secrets/test))))
+         ........(shell Append))
+         Append
+        ;---> saved as .*
+       |}
+      log;
+    Lwt.return_unit
+
 let () =
   let open Alcotest_lwt in
   Lwt_main.run begin
@@ -623,6 +652,10 @@ let () =
         test_case "Cancel 4"   `Quick test_cancel_4;
         test_case "Cancel 5"   `Quick test_cancel_5;
         test_case "Delete"     `Quick test_delete;
+      ];
+      "secrets", [
+        test_case "Simple"     `Quick test_secrets_simple;
+        test_case "No secret provided" `Quick test_secrets_not_provided;
       ];
       "manifest", [
         test_case "Copy"       `Quick test_copy;


### PR DESCRIPTION
A secret is an externally provided key-value pair that can be mounted on demand by the job. This PR implements:

- Spec: adding a `secrets` field in the `run` command, which mounts a list of secrets files in the chosen target, or in `/run/secrets/[id]` if the target is not provided. 
- Spec: when translated to docker, the secret list translate's to buildkit's `--mount=type=secret,id=[id],dst=[target]` option. 
- Obuilder: a temporary file and a mount point are created for each specified secret. Obuilder's build context has an additional `secrets` parameter in order to provide the values.