### PR TITLE
Convert --fast-sync back to a flag

### DIFF
--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -336,10 +336,9 @@ open Cmdliner
 
 let fast_sync =
   Arg.value @@
-  Arg.opt Arg.bool false @@
+  Arg.flag @@
   Arg.info
     ~doc:"Ignore sync syscalls (requires runc >= 1.0.0-rc92)"
-    ~docv:"FAST_SYNC"
     ["fast-sync"]
 
 let cmdliner : config Term.t = 


### PR DESCRIPTION
It got turned into a bool in 8225864a6e3daa (so you had to do `--fast-sync=true`), I assume by accident.

/cc @patricoferris