### PR TITLE
Support Fmt.cli and Logs.cli

### DIFF
--- a/dune
+++ b/dune
@@ -3,4 +3,4 @@
   (name main)
   (package obuilder)
   (preprocess (pps ppx_deriving.show))
-  (libraries lwt lwt.unix fmt tar-unix obuilder fmt.tty cmdliner logs.fmt))
+  (libraries lwt lwt.unix fmt fmt.cli fmt.tty tar-unix obuilder cmdliner logs.fmt logs.cli))


### PR DESCRIPTION
The first commit is just a switch to `Cmdliner.Arg.&`, I find it cleaner and it's more in line with Cmdliner's documentation, but I can remove it if you prefer. (EDIT: removed).
The second introduces support for Fmt.cli, that's the `--color=always|never|auto` flag, and support for setting logs verbosity through the command line. This introduces a bit of noise in the help page, but helps development by not having to patch the source to get more logs. The new options are only available through sub-commands.

One thing: in `setup_log`, maybe setting both
```ocaml
  Logs.set_level level;
  Logs.Src.set_level Obuilder.log_src level;
```
is redundant, I'm not sure.