### PR TITLE
Fix depreciation warnings in fmt

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -124,7 +124,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
         | Some id ->
           match Store.result t.store id with
           | None ->
-            Lwt_result.fail (`Msg (Fmt.strf "Build result %S not found" id))
+            Lwt_result.fail (`Msg (Fmt.str "Build result %S not found" id))
           | Some dir ->
             Lwt_result.return (dir / "rootfs")
     end >>!= fun src_dir ->
@@ -197,7 +197,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
   let rec run_steps t ~(context:Context.t) ~base = function
     | [] -> Lwt_result.return base
     | op :: ops ->
-      context.log `Heading Fmt.(strf "%a" (pp_op ~context) op);
+      context.log `Heading Fmt.(str "%a" (pp_op ~context) op);
       let k = run_steps t ops in
       match op with
       | `Comment _ -> k ~base ~context
@@ -222,7 +222,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
         k ~base ~context:{context with shell}
 
   let get_base t ~log base =
-    log `Heading (Fmt.strf "(from %a)" Sexplib.Sexp.pp_hum (Atom base));
+    log `Heading (Fmt.str "(from %a)" Sexplib.Sexp.pp_hum (Atom base));
     let id = Sha256.to_hex (Sha256.string base) in
     Store.build t.store ~id ~log (fun ~cancelled:_ ~log tmp ->
         Log.info (fun f -> f "Base image not present; importing %S..." base);
@@ -242,9 +242,9 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
     let rec aux context = function
       | [] -> Lwt_result.return context
       | (name, child_spec) :: child_builds ->
-        context.Context.log `Heading Fmt.(strf "(build %S ...)" name);
+        context.Context.log `Heading Fmt.(str "(build %S ...)" name);
         build ~scope t context child_spec >>!= fun child_result ->
-        context.Context.log `Note Fmt.(strf "--> finished %S" name);
+        context.Context.log `Note Fmt.(str "--> finished %S" name);
         let context = Context.with_binding name child_result context in
         aux context child_builds
     in

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -106,7 +106,7 @@ let of_saved path =
   }
 
 let printf t fmt =
-  Fmt.kstrf (write t) fmt
+  Fmt.kstr (write t) fmt
 
 let empty = {
   state = `Empty;

--- a/lib/dao.ml
+++ b/lib/dao.ml
@@ -15,7 +15,7 @@ type t = {
 
 let format_timestamp time =
   let { Unix.tm_year; tm_mon; tm_mday; tm_hour; tm_min; tm_sec; _ } = time in
-  Fmt.strf "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec
+  Fmt.str "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec
 
 let create db =
   Sqlite3.exec db {| CREATE TABLE IF NOT EXISTS builds (

--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -71,8 +71,8 @@ module Make (Raw : S.STORE) = struct
       Lwt_result.return (`Saved, id)
 
   let log_ty client_log ~id = function
-    | `Loaded -> client_log `Note (Fmt.strf "---> using %S from cache" id)
-    | `Saved -> client_log `Note (Fmt.strf "---> saved as %S" id)
+    | `Loaded -> client_log `Note (Fmt.str "---> using %S from cache" id)
+    | `Saved -> client_log `Note (Fmt.str "---> saved as %S" id)
 
   (* Check to see if we're in the process of building [id].
      If so, just tail the log from that.

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -68,7 +68,7 @@ let exec ?cwd ?stdin ?stdout ?stderr argv =
   let pp f = pp_cmd f argv in
   !lwt_process_exec ?cwd ?stdin ?stdout ?stderr ~pp ("", Array.of_list argv) >>= function
   | Ok 0 -> Lwt.return_unit
-  | Ok n -> Lwt.fail_with (Fmt.strf "%t failed with exit status %d" pp n)
+  | Ok n -> Lwt.fail_with (Fmt.str "%t failed with exit status %d" pp n)
   | Error (`Msg m) -> Lwt.fail (Failure m)
 
 let running_as_root = not (Sys.unix) || Unix.getuid () = 0

--- a/lib_spec/docker.ml
+++ b/lib_spec/docker.ml
@@ -12,7 +12,7 @@ let pp_pair f (k, v) =
 
 let pp_wrap =
   Fmt.using (String.split_on_char '\n')
-    Fmt.(list ~sep:(unit " \\@\n    ") (using String.trim string))
+    Fmt.(list ~sep:(any " \\@\n    ") (using String.trim string))
 
 let pp_cache ~ctx f { Cache.id; target; buildkit_options } =
   let buildkit_options =
@@ -22,7 +22,7 @@ let pp_cache ~ctx f { Cache.id; target; buildkit_options } =
     ("uid", string_of_int ctx.user.uid) ::
     buildkit_options
   in
-  Fmt.pf f "%a" Fmt.(list ~sep:(unit ",") pp_pair) buildkit_options
+  Fmt.pf f "%a" Fmt.(list ~sep:(any ",") pp_pair) buildkit_options
 
 let pp_mount_secret ~ctx f { Secret.id; target; buildkit_options } =
   let buildkit_options =
@@ -32,7 +32,7 @@ let pp_mount_secret ~ctx f { Secret.id; target; buildkit_options } =
     ("uid", string_of_int ctx.user.uid) ::
     buildkit_options
   in
-  Fmt.pf f "%a" Fmt.(list ~sep:(unit ",") pp_pair) buildkit_options
+  Fmt.pf f "%a" Fmt.(list ~sep:(any ",") pp_pair) buildkit_options
 
 let pp_run ~ctx f { Spec.cache; shell; secrets; network = _ } =
   Fmt.pf f "RUN %a%a%a"
@@ -84,4 +84,4 @@ let rec convert ~buildkit f (name, { Spec.child_builds; from; ops }) =
   in ()
 
 let dockerfile_of_spec ~buildkit t =
-  Fmt.strf "%a" (convert ~buildkit) (None, t)
+  Fmt.str "%a" (convert ~buildkit) (None, t)

--- a/test/test.ml
+++ b/test/test.ml
@@ -36,7 +36,7 @@ let mock_op ?(result=Lwt_result.return ()) ?(delay_store=Lwt.return_unit) ?cance
   let cmd =
     match config.argv with
     | ["/bin/bash"; "-c"; cmd] -> cmd
-    | x -> Fmt.strf "%a" Fmt.(Dump.list string) x
+    | x -> Fmt.str "%a" Fmt.(Dump.list string) x
   in
   Build_log.printf log "%s@." cmd >>= fun () ->
   cancel |> Option.iter (fun cancel ->
@@ -440,7 +440,7 @@ let test_sexp () =
     let spec = Spec.t_of_sexp s1 in
     let s2 = Spec.sexp_of_t spec in
     Alcotest.(check sexp) name s1 s2;
-    Alcotest.(check string) name s (Fmt.strf "%a" Spec.pp spec)
+    Alcotest.(check string) name s (Fmt.str "%a" Spec.pp spec)
   in
   test "copy" {|
      ((build tools


### PR DESCRIPTION
`fmt.0.8.10` deprecated `Fmt.strf`, `Fmt.kstrf`, `Fmt.unit` so this patch uses the correct functions