### PR TITLE
Added --force parameter to runc delete

### DIFF
--- a/lib/runc_sandbox.ml
+++ b/lib/runc_sandbox.ml
@@ -322,7 +322,7 @@ let clean_runc dir =
   |> Array.to_list
   |> Lwt_list.iter_s (fun item ->
       Log.warn (fun f -> f "Removing left-over runc container %S" item);
-      Os.sudo ["runc"; "--root"; dir; "delete"; item]
+      Os.sudo ["runc"; "--root"; dir; "delete"; "--force"; item]
     )
 
 let create ~state_dir (c : config) =


### PR DESCRIPTION
During start up `clean_runc` attempts to delete any left over `runc` containers, but if these containers are still running the delete operation fails and `ocluster-worker` crashes.  Adding the `--force` parameter will send a SIGKILL to the container before attempting to delete it.