### PR TITLE
Refactor `Build_log` module

### DIFF
--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -114,7 +114,7 @@ let empty = {
 }
 
 let copy ~src ~dst =
-  let buf = Bytes.create 4096 in
+  let buf = Bytes.create max_chunk_size in
   let rec aux () =
     Lwt_unix.read src buf 0 (Bytes.length buf) >>= function
     | 0 -> Lwt.return_unit


### PR DESCRIPTION
Sorry, I closed #90 by mistake.

On Windows, one cannot move a directory if it has files opened inside. A similar case occurs with ZFS. Ensure that all `Build_log` file descriptors are closed before promoting the temporary build directory and the log file it contains as definitive build result.
We can either ensure that all tailers have finished reading before closing the log file and moving the directory, or pause the tailers and resume reading from the moved log file.

I'm still ~struggling~ working on it, it's not easy, I think I always end up in some sort of deadlock where the tailers and the `Db_store` layer are waiting on each other reciprocally.
There's just a little refactoring before my attempt (that I haven't pushed yet).