### PR TITLE
Update runc to 1.1.0 and cache its download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
     # Prime the caches every Monday
     - cron: 0 1 * * MON
 
+env:
+  RUNC_VERSION: v1.1.0
+
 jobs:
   build:
     strategy:
@@ -35,5 +38,17 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - run: opam install . --deps-only --with-test
+
+      - name: Cache runc
+        id: cache-runc
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/bin/runc
+          key: ${{ env.RUNC_VERSION }}
+
+      - name: Download runc
+        if: steps.cache-runc.outputs.cache-hit != 'true'
+        run: |
+          sudo wget https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 -O /usr/local/bin/runc
 
       - run: ./.run-gha-tests.sh

--- a/.run-gha-tests.sh
+++ b/.run-gha-tests.sh
@@ -2,7 +2,6 @@
 set -eux
 export OPAMYES=true
 
-sudo wget https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.amd64 -O /usr/local/bin/runc
 sudo chmod a+x /usr/local/bin/runc
 
 sudo sh -c "cat > /usr/local/bin/uname" << EOF


### PR DESCRIPTION
The download cache is probably a drop in the ocean compared to downloading opam packages.