### PR TITLE
Rsync hard-links to save space

### DIFF
--- a/.run-gha-tests.sh
+++ b/.run-gha-tests.sh
@@ -35,9 +35,9 @@ opam exec -- make
 opam exec -- dune exec -- obuilder healthcheck --store=btrfs:/btrfs
 opam exec -- dune exec -- obuilder healthcheck --store=rsync:/rsync
 opam exec -- dune exec -- obuilder healthcheck --store=zfs:zfs
-opam exec -- dune exec -- ./stress/stress.exe btrfs:/btrfs
-opam exec -- dune exec -- ./stress/stress.exe rsync:/rsync
-opam exec -- dune exec -- ./stress/stress.exe zfs:zfs
+opam exec -- dune exec -- ./stress/stress.exe --store=btrfs:/btrfs
+opam exec -- dune exec -- ./stress/stress.exe --store=rsync:/rsync
+opam exec -- dune exec -- ./stress/stress.exe --store=zfs:zfs
 
 # Populate the caches from our own GitHub Actions cache
 btrfs subvolume create /btrfs/cache/c-opam-archives

--- a/lib/rsync_store.mli
+++ b/lib/rsync_store.mli
@@ -2,6 +2,15 @@
 
 include S.STORE
 
-val create : path:string -> t Lwt.t
-(** [create ~path] creates a new rsync store where everything will
-    be stored under [path]. *)
+type mode =
+  | Copy (** Fast but uses more disk space. *)
+  | Hardlink (** Slow but consumes less disk space. *)
+  | Hardlink_unsafe (** Reasonnably fast and uses less disk space, but no
+                        checksum verification. Only for testing during
+                        development, do not use in production. *)
+
+val create : path:string -> ?mode:mode -> unit -> t Lwt.t
+(** [create ~path ?mode ()] creates a new rsync store where everything will
+    be stored under [path]. The [mode] defaults to [Copy] and defines how
+    the caches are reused: [Copy] copies all the files, while [Hardlink] tries
+    to save disk space by sharing identical files. *)

--- a/lib/store_spec.ml
+++ b/lib/store_spec.ml
@@ -8,12 +8,14 @@ type t = [
   | `Rsync of string  (* Path for the root of the store *)
 ]
 
+let is_absolute path = not (Filename.is_relative path)
+
 let of_string s =
   match Astring.String.cut s ~sep:":" with
   | Some ("zfs", pool) -> Ok (`Zfs pool)
-  | Some ("btrfs", path) -> Ok (`Btrfs path)
-  | Some ("rsync", path) -> Ok (`Rsync path)
-  | _ -> Error (`Msg "Store must start with zfs: or btrfs:")
+  | Some ("btrfs", path) when is_absolute path -> Ok (`Btrfs path)
+  | Some ("rsync", path) when is_absolute path -> Ok (`Rsync path)
+  | _ -> Error (`Msg "Store must start with zfs: or btrfs:/ or rsync:/")
 
 let pp f = function
   | `Zfs pool -> Fmt.pf f "zfs:%s" pool

--- a/stress.sh
+++ b/stress.sh
@@ -13,6 +13,6 @@ for store in $stores; do
 done;
 for store in $stores; do
 	echo Test $store
-	dune exec ./stress/stress.exe $store
+	dune exec ./stress/stress.exe --store=$store
 done;
 echo PASS

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -211,7 +211,7 @@ end
 
 let stress spec conf =
   Lwt_main.run begin
-    Store_spec.to_store spec >>= fun (Store ((module Store), store)) ->
+    spec >>= fun (Store_spec.Store ((module Store), store)) ->
     let module T = Test(Store) in
     T.test_store store >>= fun () ->
     T.test_cache store >>= fun () ->
@@ -221,22 +221,11 @@ let stress spec conf =
 
 open Cmdliner
 
-let store_t =
-  Arg.conv Obuilder.Store_spec.(of_string, pp)
-
-let store =
-  Arg.required @@
-  Arg.pos 0 Arg.(some store_t) None @@
-  Arg.info
-    ~doc:"zfs:pool or btrfs:/path for build cache"
-    ~docv:"STORE"
-    []
-
 let cmd =
   let doc = "Run stress tests." in
   let info = Cmd.info ~doc "stress" in
   Cmd.v info
-    Term.(const stress $ store $ Sandbox.cmdliner)
+    Term.(const stress $ Store_spec.cmdliner $ Sandbox.cmdliner)
 
 
 let () =


### PR DESCRIPTION
Please note that I have **NO** idea what I'm doing: I'm working under the assumption that files are never modified in place in the store but always copied elsewhere first. If that ain't the case, well, please ignore and close this PR harshly!

I was hoping to save a bit of disk space in the obuilder store when using rsync:

```shell
/obuilder/store/result/ $ du -sh
2.1G	3438610c272ea59ea6c9b0cb93557cc430009e63f3d89d85416af6889fb94150
2.1G	ce0813553200cf888b0efa0cb2b2421dba8aaf4ba2c898d1a7dffc4483700ebd
```

Here `ce0813` was created from `343861` by running `sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam`. As a full build involves a dozen steps, the copy-everything is eating my disk alive...  But by asking nicely, rsync could observe that files from `ce0813` are identical to those in `343861` and create hard links to the originals rather than a real copy. This is obviously wrong if either can be updated in place later!

Regarding the rsync arguments:
- `--link-dest=` is the path in which the original files will be discovered (and hard-linked to). When this argument is a relative path, it is interpreted as relative to the `dst` directory (which would be plain wrong here!)... Hopefully the paths are always absolutes, hence the cmdliner quick fix to enforce it. I tried relative paths for the rsync store to see if I was breaking existing functionality, but it was already crashing `runc` because it led to the wrong store path.
  => I'm not sure if the `btrfs` backend has the same limitation? (the doc seems to imply so)

- `--checksum` may not be 100% required, but otherwise rsync might hard-link files even though they could be different as it only checks the filename, file size, modifications dates, ... and not the actual content.

Anyway, the result makes me sad. Hard-links are correctly created for files, but not directories: (because "stuff tends to break when your fs is not a tree")

```shell
/obuilder/store/result/ $ du -sh
2.1G	3438610c272ea59ea6c9b0cb93557cc430009e63f3d89d85416af6889fb94150
394M	ce0813553200cf888b0efa0cb2b2421dba8aaf4ba2c898d1a7dffc4483700ebd
```

"Everything is a file, but some files are more files than others."