### PR TITLE
Fix warnings and CI failure

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 3.3)
 (name obuilder)
 (formatting disabled)
 (generate_opam_files true)

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -22,7 +22,7 @@ module Context : sig
   *)
 end
 
-module Make (Store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) : sig
+module Make (Store : S.STORE) (Sandbox : S.SANDBOX) (_ : S.FETCHER) : sig
   include S.BUILDER with type context := Context.t
 
   val v : store:Store.t -> sandbox:Sandbox.t -> t

--- a/obuilder-spec.opam
+++ b/obuilder-spec.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocurrent/obuilder"
 doc: "https://ocurrent.github.io/obuilder/"
 bug-reports: "https://github.com/ocurrent/obuilder/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.3"}
   "fmt" {>= "0.8.9"}
   "sexplib"
   "astring"

--- a/obuilder.opam
+++ b/obuilder.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocurrent/obuilder"
 doc: "https://ocurrent.github.io/obuilder/"
 bug-reports: "https://github.com/ocurrent/obuilder/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "3.3"}
   "lwt" {>= "5.6.1"}
   "astring"
   "fmt" {>= "0.8.9"}

--- a/stress/dune
+++ b/stress/dune
@@ -1,3 +1,6 @@
-(executable
-  (name stress)
-  (libraries obuilder cmdliner fmt.tty))
+; No-op test to attach stress.exe to the obuilder package
+(test
+ (name stress)
+ (libraries obuilder cmdliner fmt.tty)
+ (package obuilder)
+ (action (progn)))

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -1,5 +1,4 @@
 type t = {
-  dir : string;
   expect :
     (cancelled:unit Lwt.t ->
      ?stdin:Obuilder.Os.unix_fd ->
@@ -22,4 +21,4 @@ let run ~cancelled ?stdin ~log t (config:Obuilder.Config.t) dir =
         | ex -> Lwt_result.fail (`Msg (Printexc.to_string ex))
       )
 
-let create dir = { dir; expect = Queue.create () }
+let create () = { expect = Queue.create () }

--- a/test/mock_sandbox.mli
+++ b/test/mock_sandbox.mli
@@ -1,6 +1,6 @@
 include Obuilder.S.SANDBOX
 
-val create : string -> t
+val create : unit -> t
 val expect :
   t -> (cancelled:unit Lwt.t ->
         ?stdin:Obuilder.Os.unix_fd ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -24,7 +24,7 @@ let get store path id =
 
 let with_config fn =
   Mock_store.with_store @@ fun store ->
-  let sandbox = Mock_sandbox.create (Mock_store.state_dir store / "sandbox") in
+  let sandbox = Mock_sandbox.create () in
   let builder = B.v ~store ~sandbox in
   let src_dir = Mock_store.state_dir store / "src" in
   Os.ensure_dir src_dir;


### PR DESCRIPTION
Bumping to Dune 3.3 enables warnings 67 (unused functor parameter) and 69 (record field is never read), which I tried fixing.
If only the `obuilder-spec` package is build, then Dune tries to build the `stress.exe` executable which requires the `obuidler` library. Use a workaround to attach `stress.exe` to the `obuilder` package.