### PR TITLE
Experimental Eio-port 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 _build
 _opam
 .vscode
+
+tar.*
+lwt_eio.*
+eioio

--- a/dune
+++ b/dune
@@ -3,4 +3,6 @@
   (name main)
   (package obuilder)
   (preprocess (pps ppx_deriving.show))
-  (libraries lwt lwt.unix fmt fmt.cli fmt.tty tar-unix obuilder cmdliner logs.fmt logs.cli))
+  (libraries eio_main fmt fmt.cli fmt.tty tar-unix obuilder cmdliner logs.fmt logs.cli))
+
+(vendored_dirs lwt_eio.0.2 eioio tar.2.0.1)

--- a/lib/btrfs_store.mli
+++ b/lib/btrfs_store.mli
@@ -2,5 +2,5 @@
 
 include S.STORE
 
-val create : string -> t Lwt.t
+val create : Eio.Process.t -> string -> t
 (** [create path] is a new store in btrfs directory [path]. *)

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1,8 +1,8 @@
-open Lwt.Infix
+open Eio
 open Sexplib.Std
 
 let ( / ) = Filename.concat
-let ( >>!= ) = Lwt_result.bind
+let ( >>!= ) = Result.bind
 
 let hostname = "builder"
 
@@ -48,6 +48,8 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
   type t = {
     store : Store.t;
     sandbox : Sandbox.t;
+    process : Process.t;
+    dir : Dir.t;
   }
 
   (* Inputs to run that should affect the hash. i.e. if anything in here changes
@@ -71,24 +73,27 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
       |> Sha256.to_hex
     in
     let { base; workdir; user; env; cmd; shell; network; mount_secrets } = run_input in
+    Switch.run @@ fun sw ->
     Store.build t.store ?switch ~base ~id ~log (fun ~cancelled ~log result_tmp ->
         let to_release = ref [] in
-        Lwt.finalize
+        Fun.protect
           (fun () ->
-             cache |> Lwt_list.map_s (fun { Obuilder_spec.Cache.id; target; buildkit_options = _ } ->
-                 Store.cache ~user t.store id >|= fun (src, release) ->
-                 to_release := release :: !to_release;
-                 { Config.Mount.src; dst = target }
-               )
-             >>= fun mounts ->
+            let mounts =  
+              Fiber.map (fun { Obuilder_spec.Cache.id; target; buildkit_options = _ } ->
+                  let src, release = Store.cache ~user t.store id in
+                  to_release := release :: !to_release;
+                  { Config.Mount.src; dst = target }
+                ) cache
+             in
              let argv = shell @ [cmd] in
              let config = Config.v ~cwd:workdir ~argv ~hostname ~user ~env ~mounts ~mount_secrets ~network in
-             Os.with_pipe_to_child @@ fun ~r:stdin ~w:close_me ->
-             Lwt_unix.close close_me >>= fun () ->
-             Sandbox.run ~cancelled ~stdin ~log t.sandbox config result_tmp
+             Os.with_pipe_to_child ~sw @@ fun ~r:stdin ~w:close_me ->
+             Flow.close close_me;
+             let stdin = (stdin :> <Flow.source; Eio_unix.unix_fd>) in
+             Sandbox.run ~sw ~dir:t.dir ~process:t.process ~cancelled ~stdin ~log t.sandbox config result_tmp
           )
-          (fun () ->
-             !to_release |> Lwt_list.iter_s (fun f -> f ())
+          ~finally:(fun () ->
+             !to_release |> Fiber.iter (fun f -> f ())
           )
       )
 
@@ -117,20 +122,20 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
     let dst = if Filename.is_relative dst then workdir / dst else dst in
     begin
       match from with
-      | `Context -> Lwt_result.return src_dir
+      | `Context -> Ok src_dir
       | `Build name ->
         match Scope.find_opt name scope with
         | None -> Fmt.failwith "Unknown build %S" name   (* (shouldn't happen; gets caught earlier) *)
         | Some id ->
           match Store.result t.store id with
           | None ->
-            Lwt_result.fail (`Msg (Fmt.str "Build result %S not found" id))
+            Error (`Msg (Fmt.str "Build result %S not found" id))
           | Some dir ->
-            Lwt_result.return (dir / "rootfs")
+            Ok (dir / "rootfs")
     end >>!= fun src_dir ->
     let src_manifest = sequence (List.map (Manifest.generate ~exclude ~src_dir) src) in
     match Result.bind src_manifest (to_copy_op ~dst) with
-    | Error _ as e -> Lwt.return e
+    | Error _ as e -> e
     | Ok op ->
       let details = {
         base;
@@ -139,6 +144,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
       } in
       (* Fmt.pr "COPY: %a@." Sexplib.Sexp.pp_hum (sexp_of_copy_details details); *)
       let id = Sha256.to_hex (Sha256.string (Sexplib.Sexp.to_string (sexp_of_copy_details details))) in
+      Switch.run @@ fun sw ->
       Store.build t.store ?switch ~base ~id ~log (fun ~cancelled ~log result_tmp ->
           let argv = ["tar"; "-xf"; "-"] in
           let config = Config.v
@@ -151,24 +157,25 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
               ~mounts:[]
               ~network:[]
           in
-          Os.with_pipe_to_child @@ fun ~r:from_us ~w:to_untar ->
-          let proc = Sandbox.run ~cancelled ~stdin:from_us ~log t.sandbox config result_tmp in
-          let send =
+          Os.with_pipe_to_child ~sw @@ fun ~r:from_us ~w:to_untar ->
+          let to_untar = Lwt_unix.of_unix_file_descr (Eio_unix.FD.peek to_untar) in
+          let result = Sandbox.run ~sw ~dir:t.dir ~process:t.process ~cancelled ~stdin:(from_us :> <Flow.source; Eio_unix.unix_fd>) ~log t.sandbox config result_tmp in
+          let () =
             (* If the sending thread finishes (or fails), close the writing socket
                immediately so that the tar process finishes too. *)
-            Lwt.finalize
+            Fun.protect
               (fun () ->
                  match op with
                  | `Copy_items (src_manifest, dst_dir) ->
-                   Tar_transfer.send_files ~src_dir ~src_manifest ~dst_dir ~to_untar ~user
+                   Lwt_eio.Promise.await_lwt 
+                   (Tar_transfer.send_files ~src_dir ~src_manifest ~dst_dir ~to_untar ~user)
                  | `Copy_item (src_manifest, dst) ->
+                  Lwt_eio.Promise.await_lwt @@
                    Tar_transfer.send_file ~src_dir ~src_manifest ~dst ~to_untar ~user
               )
-              (fun () -> Lwt_unix.close to_untar)
+              ~finally:(fun () -> Lwt_eio.Promise.await_lwt @@ Lwt_unix.close to_untar)
           in
-          proc >>= fun result ->
-          send >>= fun () ->
-          Lwt.return result
+          result
         )
 
   let pp_op ~(context:Context.t) f op =
@@ -195,7 +202,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
       (resolved_secret :: result) ) (Ok []) secrets
 
   let rec run_steps t ~(context:Context.t) ~base = function
-    | [] -> Lwt_result.return base
+    | [] -> Ok base
     | op :: ops ->
       context.log `Heading Fmt.(str "%a" (pp_op ~context) op);
       let k = run_steps t ops in
@@ -209,7 +216,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
           resolve_secrets secrets mount_secrets |> Result.map @@ fun mount_secrets ->
           (switch, { base; workdir; user; env; cmd; shell; network; mount_secrets }, log)
         in
-        Lwt.return result >>!= fun (switch, run_input, log) ->
+        result >>!= fun (switch, run_input, log) ->
         run t ~switch ~log ~cache run_input >>!= fun base ->
         k ~base ~context
       | `Copy x ->
@@ -221,41 +228,43 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
       | `Shell shell ->
         k ~base ~context:{context with shell}
 
-  let get_base t ~log base =
+  let get_base t ~sw ~log base =
     log `Heading (Fmt.str "(from %a)" Sexplib.Sexp.pp_hum (Atom base));
     let id = Sha256.to_hex (Sha256.string base) in
     Store.build t.store ~id ~log (fun ~cancelled:_ ~log tmp ->
-        Log.info (fun f -> f "Base image not present; importing %S..." base);
+        Log.info (fun f -> f "Base image not present; importing %S...%S" base tmp);
         let rootfs = tmp / "rootfs" in
-        Os.sudo ["mkdir"; "--mode=755"; "--"; rootfs] >>= fun () ->
-        Fetch.fetch ~log ~rootfs base >>= fun env ->
-        Os.write_file ~path:(tmp / "env")
-          (Sexplib.Sexp.to_string_hum Saved_context.(sexp_of_t {env})) >>= fun () ->
-        Lwt_result.return ()
+        Os.sudo ~sw ~process:t.process ["mkdir"; "--mode=755"; "--"; rootfs];
+        let env = Fetch.fetch ~sw ~log ~rootfs ~process:t.process base in
+        Os.write_file ~dir:t.dir ~path:(tmp / "env")
+          (Sexplib.Sexp.to_string_hum Saved_context.(sexp_of_t {env}));
+        Ok ()
       )
     >>!= fun id ->
     let path = Option.get (Store.result t.store id) in
     let { Saved_context.env } = Saved_context.t_of_sexp (Sexplib.Sexp.load_sexp (path / "env")) in
-    Lwt_result.return (id, env)
+    Ok (id, env)
 
-  let rec build ~scope t context { Obuilder_spec.child_builds; from = base; ops } =
+  let rec build ~scope ~dir t context { Obuilder_spec.child_builds; from = base; ops } = 
     let rec aux context = function
-      | [] -> Lwt_result.return context
+      | [] ->
+        Ok context
       | (name, child_spec) :: child_builds ->
         context.Context.log `Heading Fmt.(str "(build %S ...)" name);
-        build ~scope t context child_spec >>!= fun child_result ->
+        build ~dir ~scope t context child_spec >>!= fun child_result ->
         context.Context.log `Note Fmt.(str "--> finished %S" name);
         let context = Context.with_binding name child_result context in
         aux context child_builds
     in
     aux context child_builds >>!= fun context ->
-    get_base t ~log:context.Context.log base >>!= fun (id, env) ->
+    Switch.run @@ fun sw ->
+    get_base t ~sw ~log:context.Context.log base >>!= fun (id, env) ->
     let context = { context with env = context.env @ env } in
     run_steps t ~context ~base:id ops
 
   let build t context spec =
-    let r = build ~scope:[] t context spec in
-    (r : (string, [ `Cancelled | `Msg of string ]) Lwt_result.t :> (string, [> `Cancelled | `Msg of string ]) Lwt_result.t)
+    let r = build ~dir:t.dir ~scope:[] t context spec in
+    (r : (string, [ `Cancelled | `Msg of string ]) result :> (string, [> `Cancelled | `Msg of string ]) result)
 
   let delete ?log t id =
     Store.delete ?log t.store id
@@ -269,39 +278,36 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
     | `Output -> Buffer.add_string buffer x
 
   let healthcheck ?(timeout=30.0) t =
-    Os.with_pipe_from_child (fun ~r ~w ->
+    Switch.run @@ fun sw ->
+    Os.with_pipe_from_child ~sw (fun ~r:_ ~w ->
         let pp f = Fmt.string f "docker version" in
-        let result = Os.exec_result ~pp ~stdout:`Dev_null ~stderr:(`FD_move_safely w) ["docker"; "version"] in
-        let r = Lwt_io.(of_fd ~mode:input) r ~close:Lwt.return in
-        Lwt_io.read r >>= fun err ->
-        result >>= function
-        | Ok () -> Lwt_result.return ()
-        | Error (`Msg m) -> Lwt_result.fail (`Msg (Fmt.str "%s@.%s" m (String.trim err)))
+        let result = Os.exec_result ~sw ~process:t.process ~pp ~stderr:(w :> Flow.sink) ["docker"; "version"] in
+        result (* TODO: error message *)
       ) >>!= fun () ->
     let buffer = Buffer.create 1024 in
     let log = log_to buffer in
     (* Get the base image first, before starting the timer. *)
-    let switch = Lwt_switch.create () in
-    let context = Context.v ~switch ~log ~src_dir:"/tmp" () in
-    get_base t ~log healthcheck_base >>= function
-    | Error (`Msg _) as x -> Lwt.return x
+    let context = Context.v ~log ~src_dir:"/tmp" () in
+    Switch.run @@ fun sw ->
+    get_base t ~sw ~log healthcheck_base |> function
+    | Error (`Msg _) as x -> x
     | Error `Cancelled -> failwith "Cancelled getting base image (shouldn't happen!)"
     | Ok (id, env) ->
       let context = { context with env } in
       (* Start the timer *)
-      Lwt.async (fun () ->
-          Lwt_unix.sleep timeout >>= fun () ->
-          Lwt_switch.turn_off switch
+      Fiber.fork ~sw (fun () ->
+          Eio_unix.sleep timeout;
+          Switch.fail sw (Failure "Timeout!")
         );
-      run_steps t ~context ~base:id healthcheck_ops >>= function
-      | Ok id -> Store.delete t.store id >|= Result.ok
+      run_steps t ~context ~base:id healthcheck_ops |> function
+      | Ok id -> Store.delete t.store id |> Result.ok
       | Error (`Msg msg) as x ->
         let log = String.trim (Buffer.contents buffer) in
-        if log = "" then Lwt.return x
-        else Lwt.return (Fmt.error_msg "%s@.%s" msg log)
-      | Error `Cancelled -> Lwt.return (Fmt.error_msg "Timeout running healthcheck")
+        if log = "" then x
+        else (Fmt.error_msg "%s@.%s" msg log)
+      | Error `Cancelled -> (Fmt.error_msg "Timeout running healthcheck")
 
-  let v ~store ~sandbox =
-    let store = Store.wrap store in
-    { store; sandbox }
+  let v ~store ~sandbox ~process ~dir =
+    let store = Store.wrap dir store in
+    { store; sandbox; process; dir }
 end

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -25,5 +25,5 @@ end
 module Make (Store : S.STORE) (Sandbox : S.SANDBOX) (_ : S.FETCHER) : sig
   include S.BUILDER with type context := Context.t
 
-  val v : store:Store.t -> sandbox:Sandbox.t -> t
+  val v : store:Store.t -> sandbox:Sandbox.t -> process:Eio.Process.t -> dir:Eio.Dir.t -> t
 end

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -1,76 +1,91 @@
-open Lwt.Infix
+open Eio
 
 let max_chunk_size = 4096
 
 type t = {
   mutable state : [
-    | `Open of Lwt_unix.file_descr * unit Lwt_condition.t  (* Fires after writing more data. *)
+    | `Open of <Flow.source; Flow.sink; Flow.close> * Condition.t  (* Fires after writing more data. *)
     | `Readonly of string
     | `Empty
     | `Finished
   ];
+  dir : Dir.t;
   mutable len : int;
 }
 
-let with_dup fd fn =
-  let fd = Lwt_unix.dup ~cloexec:true fd in
-  Lwt.finalize
-    (fun () -> fn fd)
-    (fun () -> Lwt_unix.close fd)
+let with_dup ~sw (fd : 'a) fn =
+  let copy = Eio_unix.dup ~sw fd in 
+  fn copy
+  (* ~finally:(fun () -> Flow.close copy) : Closed by switch? *)
 
 let catch_cancel fn =
-  Lwt.catch fn
-    (function
-      | Lwt.Canceled -> Lwt_result.fail `Cancelled
-      | ex -> Lwt.fail ex
-    )
+  try fn () with
+      | Lwt.Canceled -> Error `Cancelled
+      | ex -> raise ex
 
 let tail ?switch t dst =
   match t.state with
   | `Finished -> invalid_arg "tail: log is finished!"
   | `Readonly path ->
-    let flags = [Unix.O_RDONLY; Unix.O_NONBLOCK; Unix.O_CLOEXEC] in
-    Lwt_io.(with_file ~mode:input ~flags) path @@ fun ch ->
-    let buf = Bytes.create max_chunk_size in
-    let rec aux () =
-      Lwt_io.read_into ch buf 0 max_chunk_size >>= function
-      | 0 -> Lwt_result.return ()
-      | n -> dst (Bytes.sub_string buf 0 n); aux ()
+    (* let flags = [Unix.O_RDONLY; Unix.O_NONBLOCK; Unix.O_CLOEXEC] in *)
+    Dir.with_open_in t.dir path @@ fun ch ->
+    (* Lwt_io.(with_file ~mode:input ~flags) path @@ fun ch -> *)
+    let buf = Cstruct.create max_chunk_size in
+    let th, cancel =
+      let th, set_th = Promise.create () in
+      Switch.run @@ fun sw ->
+      let rec aux () =
+        try 
+          match Flow.read ch (Cstruct.sub buf 0 max_chunk_size) with
+          | 0 -> Promise.resolve set_th (Ok ())
+          | n -> dst (Cstruct.to_string buf ~off:0 ~len:n); aux ()
+        with End_of_file -> Promise.resolve set_th (Ok ())
+      in
+      Fiber.fork ~sw aux;
+      th, fun () -> Switch.fail sw (Failure "cancelled")
     in
     catch_cancel @@ fun () ->
-    let th = aux () in
-    Lwt_switch.add_hook_or_exec switch (fun () -> Lwt.cancel th; Lwt.return_unit) >>= fun () ->
-    th
-  | `Empty -> Lwt_result.return ()
+    (* Option.iter (fun sw -> Switch.on_release sw cancel) switch; *)
+    (* Lwt_eio.Promise.await_lwt @@
+    Lwt_switch.add_hook_or_exec switch (fun () -> Lwt.cancel th; Lwt.return_unit); *)
+    Promise.await th
+  | `Empty -> Ok ()
   | `Open (fd, cond) ->
     (* Dup [fd], which can still work after [fd] is closed. *)
-    with_dup fd @@ fun fd ->
-    let buf = Bytes.create max_chunk_size in
+    Switch.run @@ fun sw ->
+    with_dup ~sw fd @@ fun fd ->
+    let buf = Cstruct.create max_chunk_size in
     let rec aux i =
-      match switch with
-      | Some sw when not (Lwt_switch.is_on sw) -> Lwt_result.fail `Cancelled
-      | _ ->
+      (* match switch with
+      | Some sw -> (
+        try Ok (Switch.check sw) with Cancel.Cancelled _ -> Error `Cancelled
+      )
+      | _ -> *)
         let avail = min (t.len - i) max_chunk_size in
         if avail > 0 then (
-          Lwt_unix.pread fd ~file_offset:i buf 0 avail >>= fun n ->
-          dst (Bytes.sub_string buf 0 n);
+          let n = Flow.read fd buf in
+          dst (Cstruct.to_string buf ~off:0 ~len:n);
           aux (i + avail)
         ) else (
           match t.state with
-          | `Open _ -> Lwt_condition.wait cond >>= fun () -> aux i
-          | _ -> Lwt_result.return ()
+          | `Open _ ->
+            Condition.await cond; 
+            aux i
+          | _ -> Ok ()
         )
     in
     catch_cancel @@ fun () ->
     let th = aux 0 in
-    Lwt_switch.add_hook_or_exec switch (fun () -> Lwt.cancel th; Lwt.return_unit) >>= fun () ->
+    (* Lwt_eio.Promise.await_lwt @@ *)
+    (* Lwt_switch.add_hook_or_exec switch (fun () -> Lwt.cancel th; Lwt.return_unit); *)
     th
 
-let create path =
-  Lwt_unix.openfile path Lwt_unix.[O_CREAT; O_TRUNC; O_RDWR; O_CLOEXEC] 0o666 >|= fun fd ->
-  let cond = Lwt_condition.create () in
+let create ~sw ~dir path =
+  let fd = Dir.open_out ~sw dir path ~create:(`Or_truncate 0o666) in
+  let cond = Condition.create () in
   {
-    state = `Open (fd, cond);
+    state = `Open ((fd :> <Flow.source; Flow.sink; Flow.close>), cond);
+    dir;
     len = 0;
   }
 
@@ -79,13 +94,11 @@ let finish t =
   | `Finished -> invalid_arg "Log is already finished!"
   | `Open (fd, cond) ->
     t.state <- `Finished;
-    Lwt_unix.close fd >|= fun () ->
-    Lwt_condition.broadcast cond ()
+    Flow.close fd;
+    Condition.broadcast cond;
   | `Readonly _ ->
-    t.state <- `Finished;
-    Lwt.return_unit
-  | `Empty ->
-    Lwt.return_unit (* Empty can be reused *)
+    t.state <- `Finished
+  | `Empty -> () (* Empty can be reused *)
 
 let write t data =
   match t.state with
@@ -93,31 +106,34 @@ let write t data =
   | `Readonly _ | `Empty -> invalid_arg "Log is read-only!"
   | `Open (fd, cond) ->
     let len = String.length data in
-    Os.write_all fd (Bytes.of_string data) 0 len >>= fun () ->
+    Os.write_all fd (Cstruct.of_string data) 0 len;
     t.len <- t.len + len;
-    Lwt_condition.broadcast cond ();
-    Lwt.return_unit
+    Condition.broadcast cond
 
-let of_saved path =
-  Lwt_unix.lstat path >|= fun stat ->
+let of_saved dir path =
+  let stat = Eio_unix.run_in_systhread @@ fun () -> Unix.lstat path in 
   {
     state = `Readonly path;
+    dir;
     len = stat.st_size;
   }
 
 let printf t fmt =
   Fmt.kstr (write t) fmt
 
-let empty = {
+let empty dir = {
   state = `Empty;
+  dir;
   len = 0;
 }
 
 let copy ~src ~dst =
-  let buf = Bytes.create 4096 in
+  let buf = Cstruct.create 4096 in
   let rec aux () =
-    Lwt_unix.read src buf 0 (Bytes.length buf) >>= function
-    | 0 -> Lwt.return_unit
-    | n -> write dst (Bytes.sub_string buf 0 n) >>= aux
+    match Eio.Flow.read src buf with
+    | 0 -> ()
+    | n -> 
+      write dst (Cstruct.to_string buf ~off:0 ~len:n);
+      aux ()
   in
   aux ()

--- a/lib/build_log.mli
+++ b/lib/build_log.mli
@@ -3,37 +3,37 @@ type t
 
 (** {2 Creating logs} *)
 
-val create : string -> t Lwt.t
+val create : sw:Eio.Switch.t -> dir:Eio.Dir.t -> string -> t
 (** [create path] creates a new log file at temporary location [path].
     Call [finish] when done to release the file descriptor. *)
 
-val finish : t -> unit Lwt.t
+val finish : t -> unit
 (** [finish t] marks log [t] as finished.
     If it was open for writing, this closes the file descriptor.
     It cannot be used after this (for reading or writing), although existing
     background operations (e.g. [tail]) can continue successfully. *)
 
-val write : t -> string -> unit Lwt.t
+val write : t -> string -> unit
 (** [write t data] appends [data] to the log. *)
 
-val printf : t -> ('a, Format.formatter, unit, unit Lwt.t) format4 -> 'a
+val printf : t -> ('a, Format.formatter, unit, unit) format4 -> 'a
 (** [printf t fmt] is a wrapper for [write t] that takes a format string. *)
 
 (** {2 Reading logs} *)
 
-val empty : t
+val empty : Eio.Dir.t -> t
 (** [empty] is a read-only log with no content. *)
 
-val of_saved : string -> t Lwt.t
+val of_saved : Eio.Dir.t -> string -> t
 (** [of_saved path] is a read-only log which reads from [path]. *)
 
-val tail : ?switch:Lwt_switch.t -> t -> (string -> unit) -> (unit, [> `Cancelled]) Lwt_result.t
+val tail : ?switch:Lwt_switch.t -> t -> (string -> unit) -> (unit, [> `Cancelled]) result
 (** [tail t dst] streams data from the log to [dst].
     This can be called at any time before [finish] is called.
     @param switch Abort if this is turned off. *)
 
 (* {2 Copying to logs} *)
 
-val copy : src:Lwt_unix.file_descr -> dst:t -> unit Lwt.t
+val copy : src:<Eio.Flow.source; Eio_unix.unix_fd> -> dst:t -> unit
 (** [copy ~src ~dst] reads bytes from the [src] file descriptor and
     writes them to the build log [dst]. *)

--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -1,20 +1,21 @@
-open Lwt.Infix
+open Eio
 
 let ( / ) = Filename.concat
-let ( >>!= ) = Lwt_result.bind
+let ( >>!= ) = Result.bind
 
 module Make (Raw : S.STORE) = struct
   type build = {
     mutable users : int;
-    set_cancelled : unit Lwt.u;         (* Resolve this to cancel (when [users = 0]). *)
-    log : Build_log.t Lwt.t;
-    result : (([`Loaded | `Saved] * S.id), [`Cancelled | `Msg of string]) Lwt_result.t;
+    set_cancelled : unit Promise.u;         (* Resolve this to cancel (when [users = 0]). *)
+    log : (Build_log.t, exn) result Promise.t;
+    result : (([`Loaded | `Saved] * S.id), [`Cancelled | `Msg of string]) result Promise.t;
   }
 
   module Builds = Map.Make(String)
 
   type t = {
     raw : Raw.t;
+    dir : Eio.Dir.t;
     dao : Dao.t;
     (* Invariants for builds in [in_progress]:
        - [result] is still pending and [log] isn't finished.
@@ -23,51 +24,51 @@ module Make (Raw : S.STORE) = struct
   }
 
   let finish_log ~set_log log =
-    match Lwt.state log with
-    | Lwt.Return log ->
+    match Promise.peek log with
+    | Some (Ok log) ->
       Build_log.finish log
-    | Lwt.Fail _ ->
-      Lwt.return_unit
-    | Lwt.Sleep ->
-      Lwt.wakeup_exn set_log (Failure "Build ended without setting a log!");
-      Lwt.return_unit
+    | Some _ -> ()
+    | None ->
+      Promise.resolve_error set_log (Failure "Build ended without setting a log!")
 
   let dec_ref build =
     build.users <- build.users - 1;
-    if Lwt.is_sleeping build.result then (
+    if Promise.is_resolved build.result then (
       Log.info (fun f -> f "User cancelled job (users now = %d)" build.users);
       if build.users = 0 then (
-        Lwt.wakeup_later build.set_cancelled ()
+        Promise.resolve build.set_cancelled ()
       )
     )
 
   (* Get the result for [id], either by loading it from the disk cache
      or by doing a new build using [fn]. We only run one instance of this
      at a time for a single [id]. *)
-  let get_build t ~base ~id ~cancelled ~set_log fn =
+  let get_build t ~sw ~base ~id ~cancelled ~set_log fn =
     match Raw.result t.raw id with
     | Some dir ->
       let now = Unix.(gmtime (gettimeofday ())) in
       Dao.set_used t.dao ~id ~now;
       let log_file = dir / "log" in
-      begin
-        if Sys.file_exists log_file then Build_log.of_saved log_file
-        else Lwt.return Build_log.empty
-      end >>= fun log ->
-      Lwt.wakeup set_log log;
-      Lwt_result.return (`Loaded, id)
+      let log =
+        if Sys.file_exists log_file then Build_log.of_saved t.dir log_file
+        else Build_log.empty t.dir
+      in
+      Promise.resolve set_log (Ok log);
+      Ok (`Loaded, id)
     | None ->
-      Raw.build t.raw ?base ~id (fun dir ->
+      match Raw.build t.raw ?base ~id (fun dir ->
           let log_file = dir / "log" in
           if Sys.file_exists log_file then Unix.unlink log_file;
-          Build_log.create log_file >>= fun log ->
-          Lwt.wakeup set_log log;
+          let log = Build_log.create ~sw ~dir:t.dir log_file in
+          Promise.resolve set_log (Ok log);
           fn ~cancelled ~log dir
         )
-      >>!= fun () ->
+          with 
+      | Error _ as e -> e
+      | Ok () ->
       let now = Unix.(gmtime (gettimeofday () )) in
       Dao.add t.dao ?parent:base ~id ~now;
-      Lwt_result.return (`Saved, id)
+      Ok (`Saved, id)
 
   let log_ty client_log ~id = function
     | `Loaded -> client_log `Note (Fmt.str "---> using %S from cache" id)
@@ -83,46 +84,54 @@ module Make (Raw : S.STORE) = struct
     match Builds.find_opt id t.in_progress with
     | Some existing when existing.users = 0 ->
       client_log `Note ("Waiting for previous build to finish cancelling");
-      assert (Lwt.is_sleeping existing.result);
-      existing.result >>= fun _ ->
+      assert (not (Promise.is_resolved existing.result));
+      let _ = Promise.await existing.result in
       build ?switch t ?base ~id ~log:client_log fn
     | Some existing ->
       (* We're already building this, and the build hasn't been cancelled. *)
       existing.users <- existing.users + 1;
-      existing.log >>= fun log ->
-      Lwt_switch.add_hook_or_exec switch (fun () -> dec_ref existing; Lwt.return_unit) >>= fun () ->
+      let log = Promise.await_exn existing.log in
+      (* Option.iter (fun sw -> Switch.on_release sw (fun () -> dec_ref existing)) switch; *)
+      (* Lwt_switch.add_hook_or_exec switch (fun () -> dec_ref existing; Lwt.return_unit) >>= fun () -> *)
       Build_log.tail ?switch log (client_log `Output) >>!= fun () ->
-      existing.result >>!= fun (ty, r) ->
+      Promise.await existing.result >>!= fun (ty, r) ->
       log_ty client_log ~id ty;
-      Lwt_result.return r
+      Ok r
     | None ->
-      let result, set_result = Lwt.wait () in
-      let log, set_log = Lwt.wait () in
-      let tail_log = log >>= fun log -> Build_log.tail ?switch log (client_log `Output) in
-      let cancelled, set_cancelled = Lwt.wait () in
+      let result, set_result = Promise.create () in
+      let log, set_log = Promise.create () in
+      let tail_log, set_tl = Promise.create () in
+      let cancelled, set_cancelled = Promise.create () in
       let build = { users = 1; set_cancelled; log; result } in
-      Lwt_switch.add_hook_or_exec switch (fun () -> dec_ref build; Lwt.return_unit) >>= fun () ->
+      (* Lwt_switch.add_hook_or_exec switch (fun () -> dec_ref build; Lwt.return_unit) >>= fun () -> *)
       t.in_progress <- Builds.add id build t.in_progress;
-      Lwt.async
+      Switch.run @@ fun sw ->
+      Fiber.both
+        (fun () -> 
+          match Promise.await log with
+          | Ok log ->
+             let v = Build_log.tail ?switch log (client_log `Output) in
+             Promise.resolve set_tl v
+          | _ -> assert false
+        )
         (fun () ->
-           Lwt.try_bind
-             (fun () -> get_build t ~base ~id ~cancelled ~set_log fn)
-             (fun r ->
-                t.in_progress <- Builds.remove id t.in_progress;
-                Lwt.wakeup_later set_result r;
-                finish_log ~set_log log
-             )
-             (fun ex ->
+           try
+              let r = get_build t ~sw ~base ~id ~cancelled ~set_log fn in
+              Fiber.yield ();
+              t.in_progress <- Builds.remove id t.in_progress;
+              Promise.resolve set_result r;
+              finish_log ~set_log log
+           with
+              ex ->
                 Log.info (fun f -> f "Build %S error: %a" id Fmt.exn ex);
                 t.in_progress <- Builds.remove id t.in_progress;
-                Lwt.wakeup_later_exn set_result ex;
+                Promise.resolve_error set_result (`Msg (Printexc.to_string ex));
                 finish_log ~set_log log
-             )
         );
-      tail_log >>!= fun () ->
-      result >>!= fun (ty, r) ->
+      Promise.await tail_log >>!= fun () ->
+      Promise.await result >>!= fun (ty, r) ->
       log_ty client_log ~id ty;
-      Lwt_result.return r
+      Ok r
 
   let result t id = Raw.result t.raw id
   let cache ~user t = Raw.cache ~user t.raw
@@ -135,9 +144,9 @@ module Make (Raw : S.STORE) = struct
         Log.warn (fun f -> f "ID %S not in database!" id);
         Raw.delete t.raw id     (* Try removing it anyway *)
       | Ok deps ->
-        Lwt_list.iter_s aux deps >>= fun () ->
+        Fiber.iter aux deps;
         log id;
-        Raw.delete t.raw id >|= fun () ->
+        Raw.delete t.raw id;
         Dao.delete t.dao id
     in
     aux id
@@ -146,31 +155,30 @@ module Make (Raw : S.STORE) = struct
     let items = Dao.lru t.dao ~before limit in
     let n = List.length items in
     Log.info (fun f -> f "Pruning %d items (of %d requested)" n limit);
-    items |> Lwt_list.iter_s (fun id ->
+    items |> Fiber.iter (fun id ->
         log id;
-        Raw.delete t.raw id >|= fun () ->
+        Raw.delete t.raw id;
         Dao.delete t.dao id
-      )
-    >>= fun () ->
-    Lwt.return n
+      );
+    n
 
   let prune ?log t ~before limit =
     let rec aux acc limit =
-      if limit = 0 then Lwt.return acc  (* Pruned everything we wanted to *)
+      if limit = 0 then acc  (* Pruned everything we wanted to *)
       else (
-        prune_batch ?log t ~before limit >>= function
-        | 0 -> Lwt.return acc           (* Nothing left to prune *)
+        prune_batch ?log t ~before limit |> function
+        | 0 -> acc           (* Nothing left to prune *)
         | n -> aux (acc + n) (limit - n)
       )
     in
-    aux 0 limit >>= fun n ->
-    Raw.complete_deletes t.raw >>= fun () ->
-    Lwt.return n
+    let n = aux 0 limit in
+    Raw.complete_deletes t.raw;
+    n
 
-  let wrap raw =
+  let wrap dir raw =
     let db_dir = Raw.state_dir raw / "db" in
     Os.ensure_dir db_dir;
     let db = Db.of_dir (db_dir / "db.sqlite") in
     let dao = Dao.create db in
-    { raw; dao; in_progress = Builds.empty }
+    { raw; dao; dir; in_progress = Builds.empty }
 end

--- a/lib/db_store.mli
+++ b/lib/db_store.mli
@@ -1,3 +1,5 @@
+open Eio
+
 module Make (Raw : S.STORE) : sig
   type t
 
@@ -6,17 +8,17 @@ module Make (Raw : S.STORE) : sig
     t -> ?base:S.id ->
     id:S.id ->
     log:S.logger ->
-    (cancelled:unit Lwt.t -> log:Build_log.t -> string -> (unit, [`Cancelled | `Msg of string]) Lwt_result.t) ->
-    (S.id, [`Cancelled | `Msg of string]) Lwt_result.t
+    (cancelled:unit Promise.t -> log:Build_log.t -> string -> (unit, [`Cancelled | `Msg of string]) result) ->
+    (S.id, [`Cancelled | `Msg of string]) result
   (** [build t ~id ~log fn] ensures that [id] is cached, using [fn ~cancelled ~log dir] to build it if not.
       If [cancelled] resolves, the build should be cancelled.
       If [id] is already in the process of being built, this just attaches to the existing build.
       @param switch Turn this off if you no longer need the result. The build
                     will be cancelled if no-one else is waiting for it. *)
 
-  val delete : ?log:(S.id -> unit) -> t -> S.id -> unit Lwt.t
+  val delete : ?log:(S.id -> unit) -> t -> S.id -> unit
 
-  val prune : ?log:(S.id -> unit) -> t -> before:Unix.tm -> int -> int Lwt.t
+  val prune : ?log:(S.id -> unit) -> t -> before:Unix.tm -> int -> int
 
   val result : t -> S.id -> string option
 
@@ -24,7 +26,7 @@ module Make (Raw : S.STORE) : sig
     user : Obuilder_spec.user ->
     t ->
     string ->
-    (string * (unit -> unit Lwt.t)) Lwt.t
+    (string * (unit -> unit))
 
-  val wrap : Raw.t -> t
+  val wrap : Eio.Dir.t -> Raw.t -> t
 end

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
   (name obuilder)
   (public_name obuilder)
   (preprocess (pps ppx_sexp_conv))
-  (libraries lwt lwt.unix fmt yojson tar-unix sexplib sqlite3 astring logs sha obuilder-spec cmdliner))
+  (libraries eio eio.unix lwt_eio fmt yojson tar-unix sexplib sqlite3 astring logs sha obuilder-spec cmdliner))

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -88,6 +88,7 @@ let with_pipe_from_child ~sw fn =
 
 let with_pipe_to_child ~sw fn =
   let r, w = Eio_unix.pipe sw in
+  Logs.info (fun f -> f "pipiing");
   Fun.protect
     (fun () -> fn ~r ~w)
     ~finally:(fun () ->

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -1,23 +1,11 @@
-open Lwt.Infix
+open Eio
 
-let ( >>!= ) = Lwt_result.bind
+let _close fd =
+  match Eio_unix.FD.take_opt fd with
+  | Some fd -> Unix.close fd
+  | None -> assert false
 
-type unix_fd = {
-  raw : Unix.file_descr;
-  mutable needs_close : bool;
-}
-
-let close fd =
-  assert (fd.needs_close);
-  Unix.close fd.raw;
-  fd.needs_close <- false
-
-let ensure_closed_unix fd =
-  if fd.needs_close then close fd
-
-let ensure_closed_lwt fd =
-  if Lwt_unix.state fd = Lwt_unix.Closed then Lwt.return_unit
-  else Lwt_unix.close fd
+let ensure_closed_unix _fd = ()
 
 let pp_signal f x =
   let open Sys in
@@ -28,48 +16,45 @@ let pp_signal f x =
 let pp_cmd = Fmt.box Fmt.(list ~sep:sp (quote string))
 
 let redirection = function
-  | `FD_move_safely x -> `FD_copy x.raw
+  | `FD_move_safely x -> `FD_copy x
   | `Dev_null -> `Dev_null
 
-let close_redirection (x : [`FD_move_safely of unix_fd | `Dev_null]) =
-  match x with
-  | `FD_move_safely x -> ensure_closed_unix x
-  | `Dev_null -> ()
+let close_redirection flow = ensure_closed_unix flow
 
 (* stdin, stdout and stderr are copied to the child and then closed on the host.
    They are closed at most once, so duplicates are OK. *)
-let default_exec ?cwd ?stdin ?stdout ?stderr ~pp argv =
+let default_exec ?cwd ?stdin ?stdout ?stderr ~sw ~(process:Process.t) ~pp (v, argv) =
   let proc =
-    let stdin  = Option.map redirection stdin in
-    let stdout = Option.map redirection stdout in
-    let stderr = Option.map redirection stderr in
-    Lwt_process.exec ?cwd ?stdin ?stdout ?stderr argv
+    (* let _stdin  = Option.map redirection stdin in
+    let _stdout = Option.map redirection stdout in
+    let _stderr = Option.map redirection stderr in *)
+    Process.spawn ?cwd ?stdin ?stdout ?stderr ~sw process v argv
   in
-  Option.iter close_redirection stdin;
+  (* Option.iter close_redirection stdin;
   Option.iter close_redirection stdout;
-  Option.iter close_redirection stderr;
-  proc >|= function
-  | Unix.WEXITED n -> Ok n
-  | Unix.WSIGNALED x -> Fmt.error_msg "%t failed with signal %d" pp x
-  | Unix.WSTOPPED x -> Fmt.error_msg "%t stopped with signal %a" pp pp_signal x
+  Option.iter close_redirection stderr; *)
+  match Process.status proc with
+  | Exited n -> Ok n
+  | Signaled x -> Fmt.error_msg "%t failed with signal %d" pp x
+  | Stopped x -> Fmt.error_msg "%t stopped with signal %a" pp pp_signal x
 
 (* Overridden in unit-tests *)
-let lwt_process_exec = ref default_exec
+let eio_process_exec = ref default_exec
 
-let exec_result ?cwd ?stdin ?stdout ?stderr ~pp argv =
+let exec_result ?cwd ?stdin ?stdout ?stderr ~sw ~process ~pp argv =
   Logs.info (fun f -> f "Exec %a" pp_cmd argv);
-  !lwt_process_exec ?cwd ?stdin ?stdout ?stderr ~pp ("", Array.of_list argv) >>= function
-  | Ok 0 -> Lwt_result.return ()
-  | Ok n -> Lwt.return @@ Fmt.error_msg "%t failed with exit status %d" pp n
-  | Error e -> Lwt_result.fail (e : [`Msg of string] :> [> `Msg of string])
+  match !eio_process_exec ?cwd ?stdin ?stdout ?stderr ~sw ~process ~pp ("", argv) with
+  | Ok 0 -> Ok ()
+  | Ok n -> Fmt.error_msg "%t failed with exit status %d" pp n
+  | Error e -> Error (e : [`Msg of string] :> [> `Msg of string])
 
-let exec ?cwd ?stdin ?stdout ?stderr argv =
+let exec ?cwd ?stdin ?stdout ?stderr ~sw ~process argv =
   Logs.info (fun f -> f "Exec %a" pp_cmd argv);
   let pp f = pp_cmd f argv in
-  !lwt_process_exec ?cwd ?stdin ?stdout ?stderr ~pp ("", Array.of_list argv) >>= function
-  | Ok 0 -> Lwt.return_unit
-  | Ok n -> Lwt.fail_with (Fmt.str "%t failed with exit status %d" pp n)
-  | Error (`Msg m) -> Lwt.fail (Failure m)
+  match !eio_process_exec ?cwd ?stdin ?stdout ?stderr ~sw ~process ~pp ("", argv) with
+  | Ok 0 -> ()
+  | Ok n -> failwith (Fmt.str "%t failed with exit status %d" pp n)
+  | Error (`Msg m) -> raise (Failure m)
 
 let running_as_root = not (Sys.unix) || Unix.getuid () = 0
 
@@ -81,61 +66,64 @@ let sudo_result ?cwd ?stdin ?stdout ?stderr ~pp args =
   let args = if running_as_root then args else "sudo" :: args in
   exec_result ?cwd ?stdin ?stdout ?stderr ~pp args
 
-let rec write_all fd buf ofs len =
+let write_all fd buf off len =
   assert (len >= 0);
-  if len = 0 then Lwt.return_unit
+  if len = 0 then ()
   else (
-    Lwt_unix.write fd buf ofs len >>= fun n ->
-    write_all fd buf (ofs + n) (len - n)
+    Flow.copy (Flow.cstruct_source [ Cstruct.sub buf off len ]) fd
   )
 
-let write_file ~path contents =
-  let flags = [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC; Unix.O_NONBLOCK; Unix.O_CLOEXEC] in
-  Lwt_io.(with_file ~mode:output ~flags) path @@ fun ch ->
-  Lwt_io.write ch contents
+let write_file ~dir ~path contents =
+  (* let flags = [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC; Unix.O_NONBLOCK; Unix.O_CLOEXEC] in *)
+  Dir.save ~create:(`Or_truncate 0o600) dir path contents
 
-let with_pipe_from_child fn =
-  let r, w = Lwt_unix.pipe_in ~cloexec:true () in
-  let w = { raw = w; needs_close = true } in
-  Lwt.finalize
+let with_pipe_from_child ~sw fn =
+  let r, w = Eio_unix.pipe sw in
+  Fun.protect
     (fun () -> fn ~r ~w)
-    (fun () ->
+    ~finally:(fun () ->
        ensure_closed_unix w;
-       ensure_closed_lwt r
+       ensure_closed_unix r
     )
 
-let with_pipe_to_child fn =
-  let r, w = Lwt_unix.pipe_out ~cloexec:true () in
-  let r = { raw = r; needs_close = true } in
-  Lwt.finalize
+let with_pipe_to_child ~sw fn =
+  let r, w = Eio_unix.pipe sw in
+  Fun.protect
     (fun () -> fn ~r ~w)
-    (fun () ->
+    ~finally:(fun () ->
        ensure_closed_unix r;
-       ensure_closed_lwt w
+       ensure_closed_unix w
     )
 
-let with_pipe_between_children fn =
-  let r, w = Unix.pipe ~cloexec:true () in
-  let r = { raw = r; needs_close = true } in
-  let w = { raw = w; needs_close = true } in
-  Lwt.finalize
+let with_pipe_between_children ~sw fn =
+  let r, w = Eio_unix.pipe sw in
+  Fun.protect
     (fun () -> fn ~r ~w)
-    (fun () ->
+    ~finally:(fun () ->
        ensure_closed_unix r;
-       ensure_closed_unix w;
-       Lwt.return_unit
+       ensure_closed_unix w
     )
 
-let pread ?stderr argv =
-  with_pipe_from_child @@ fun ~r ~w ->
-  let child = exec ~stdout:(`FD_move_safely w) ?stderr argv in
-  let r = Lwt_io.(of_fd ~mode:input) r in
-  Lwt.finalize
-    (fun () -> Lwt_io.read r)
-    (fun () -> Lwt_io.close r)
-  >>= fun data ->
-  child >>= fun () ->
-  Lwt.return data
+let read_all ?(size=512) flow =
+  let rec aux acc =
+    try 
+      let buf = Cstruct.create size in
+      let i = Flow.read flow buf in
+      aux (Cstruct.sub buf 0 i :: acc)
+    with
+      | End_of_file -> List.rev acc |> Cstruct.concat |> Cstruct.to_string
+  in
+    aux []
+
+let pread ?stderr ~sw ~process argv =
+  with_pipe_from_child ~sw @@ fun ~r ~w ->
+  let () = exec ~sw ~process ~stdout:(w :> Flow.sink) ?stderr argv in
+  let data = 
+    Fun.protect
+      (fun () -> read_all ~size:64000 r)
+      ~finally:(fun () -> ())
+  in
+  data
 
 let check_dir x =
   match Unix.lstat x with

--- a/lib/rsync_store.ml
+++ b/lib/rsync_store.ml
@@ -1,12 +1,12 @@
 (* The rsync backend is intended for stability, portability and testing. It
    is not supposed to be fast nor is it supposed to be particularly memory
    efficient. *)
-open Lwt.Infix
+open Eio
 
 (* The caching approach (and much of the code) is copied from the btrfs 
    implementation *)
 type cache = {
-  lock : Lwt_mutex.t;
+  lock : Mutex.t;
   mutable gen : int;
 }
 
@@ -18,6 +18,7 @@ type mode =
 type t = {
     path : string;
     mode : mode;
+    process : Eio.Process.t;
     caches : (string, cache) Hashtbl.t;
     mutable next : int;
 }
@@ -25,7 +26,7 @@ type t = {
 let ( / ) = Filename.concat
 
 module Rsync = struct
-  let create dir = Lwt.return @@ Os.ensure_dir dir
+  let create dir = Os.ensure_dir dir
 
   let delete dir =
     Os.sudo [ "rm"; "-r"; dir ]
@@ -36,8 +37,10 @@ module Rsync = struct
     let cmd = [ "mv"; src; dst ] in
     Os.sudo cmd
 
-  let rename_with_sharing ~mode ~base ~src ~dst = match mode, base with
-    | Copy, _ | _, None -> rename ~src ~dst
+  let rename_with_sharing ~process ~mode ~base ~src ~dst = 
+    Switch.run @@ fun sw ->
+    match mode, base with
+    | Copy, _ | _, None -> rename ~sw ~process ~src ~dst
     | _, Some base ->
         (* Attempt to hard-link existing files shared with [base] *)
         let safe = match mode with
@@ -46,8 +49,8 @@ module Rsync = struct
         in
         let cmd = rsync @ safe @ ["--link-dest=" ^ base; src ^ "/"; dst ] in
         Os.ensure_dir dst;
-        Os.sudo cmd >>= fun () ->
-        delete src
+        Os.sudo ~sw ~process cmd;
+        delete ~sw ~process src
 
   let copy_children ?chown ~src ~dst () =
     let chown = match chown with
@@ -79,41 +82,40 @@ module Path = struct
   let result_tmp t id = t.path / result_tmp_dirname / id
 end
 
-let create ~path ?(mode = Copy) () =
-  Rsync.create path >>= fun () ->
-  Lwt_list.iter_s Rsync.create (Path.dirs path) >|= fun () ->
-  { path; mode; caches = Hashtbl.create 10; next = 0 }
+let create ~process ~path ?(mode = Copy) () =
+  Rsync.create path;
+  Fiber.iter Rsync.create (Path.dirs path);
+  { path; process; mode; caches = Hashtbl.create 10; next = 0 }
 
 let build t ?base ~id fn =
   Log.debug (fun f -> f "rsync: build %S" id);
+  Switch.run @@ fun sw ->
   let result = Path.result t id in
   let result_tmp = Path.result_tmp t id in
   let base = Option.map (Path.result t) base in
   begin match base with
   | None -> Rsync.create result_tmp
-  | Some src -> Rsync.copy_children ~src ~dst:result_tmp ()
-  end
-  >>= fun () ->
-  Lwt.try_bind
-      (fun () -> fn result_tmp)
-      (fun r ->
-      begin match r with
-          | Ok () -> Rsync.rename_with_sharing ~mode:t.mode ~base ~src:result_tmp ~dst:result
-          | Error _ -> Lwt.return_unit
-      end >>= fun () ->
-      Lwt.return r
-      )
-  (fun ex ->
+  | Some src -> Rsync.copy_children ~sw ~process:t.process ~src ~dst:result_tmp ()
+  end;
+  try
+    let r = fn result_tmp in
+    begin 
+      match r with
+      | Ok () -> Rsync.rename_with_sharing ~process:t.process ~mode:t.mode ~base ~src:result_tmp ~dst:result
+      | Error _ -> ()
+    end;
+    r
+  with ex ->
       Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
-      Rsync.delete result_tmp >>= fun () ->
-      Lwt.fail ex
-  )
+      Rsync.delete ~sw ~process:t.process result_tmp;
+      raise ex
 
 let delete t id =
+  Switch.run @@ fun sw ->
   let path = Path.result t id in
   match Os.check_dir path with
-    | `Present -> Rsync.delete path
-    | `Missing -> Lwt.return_unit
+    | `Present -> Rsync.delete ~sw ~process:t.process path
+    | `Missing -> ()
 
 let result t id =
   let dir = Path.result t id in
@@ -127,49 +129,51 @@ let get_cache t name =
   match Hashtbl.find_opt t.caches name with
   | Some c -> c
   | None ->
-    let c = { lock = Lwt_mutex.create (); gen = 0 } in
+    let c = { lock = Mutex.create (); gen = 0 } in
     Hashtbl.add t.caches name c;
     c
 
 let cache ~user t name =
+  Switch.run @@ fun sw ->
   let cache = get_cache t name in
-  Lwt_mutex.with_lock cache.lock @@ fun () ->
+  Mutex.use_ro cache.lock @@ fun () ->
   let tmp = Path.cache_tmp t t.next name in
   t.next <- t.next + 1;
   let snapshot = Path.cache t name in
   (* Create cache if it doesn't already exist. *)
   begin match Os.check_dir snapshot with
       | `Missing -> Rsync.create snapshot
-      | `Present -> Lwt.return_unit
-  end >>= fun () ->
+      | `Present -> ()
+  end;
   (* Create writeable clone. *)
   let gen = cache.gen in
   let { Obuilder_spec.uid; gid } = user in
-  Rsync.copy_children ~chown:(Printf.sprintf "%d:%d" uid gid) ~src:snapshot ~dst:tmp () >>= fun () ->
+  Rsync.copy_children ~sw ~process:t.process ~chown:(Printf.sprintf "%d:%d" uid gid) ~src:snapshot ~dst:tmp ();
   let release () =
-      Lwt_mutex.with_lock cache.lock @@ fun () ->
+      Mutex.use_ro cache.lock @@ fun () ->
       begin
       if cache.gen = gen then (
           (* The cache hasn't changed since we cloned it. Update it. *)
           (* todo: check if it has actually changed. *)
           cache.gen <- cache.gen + 1;
-          Rsync.delete snapshot >>= fun () ->
-          Rsync.rename ~src:tmp ~dst:snapshot
-      ) else Lwt.return_unit
+          Rsync.delete ~sw ~process:t.process snapshot;
+          Rsync.rename ~sw ~process:t.process ~src:tmp ~dst:snapshot
+      ) else ()
       end
   in
-  Lwt.return (tmp, release)
+  (tmp, release)
 
 
 let delete_cache t name =
+  Switch.run @@ fun sw ->
   let cache = get_cache t name in
-  Lwt_mutex.with_lock cache.lock @@ fun () ->
+  Mutex.use_ro cache.lock @@ fun () ->
   cache.gen <- cache.gen + 1;   (* Ensures in-progress writes will be discarded *)
   let snapshot = Path.cache t name in
   if Sys.file_exists snapshot then (
-      Rsync.delete snapshot >>= fun () ->
-      Lwt_result.return ()
-  ) else Lwt_result.return ()
+      Rsync.delete ~sw ~process:t.process snapshot
+  );
+  Ok ()
 
 (* Don't think this applies to rsync *)
-let complete_deletes _t = Lwt.return ()
+let complete_deletes _t = ()

--- a/lib/rsync_store.mli
+++ b/lib/rsync_store.mli
@@ -9,8 +9,8 @@ type mode =
                         checksum verification. Only for testing during
                         development, do not use in production. *)
 
-val create : path:string -> ?mode:mode -> unit -> t Lwt.t
-(** [create ~path ?mode ()] creates a new rsync store where everything will
+val create : process:Eio.Process.t -> path:string -> ?mode:mode -> unit -> t
+(** [create ~process ~path ?mode ()] creates a new rsync store where everything will
     be stored under [path]. The [mode] defaults to [Copy] and defines how
     the caches are reused: [Copy] copies all the files, while [Hardlink] tries
     to save disk space by sharing identical files. *)

--- a/lib/runc_sandbox.mli
+++ b/lib/runc_sandbox.mli
@@ -9,6 +9,6 @@ val cmdliner : config Cmdliner.Term.t
 (** [cmdliner] is used for command-line interfaces to generate the necessary flags
     and parameters to setup a specific sandbox's configuration. *)
 
-val create : state_dir:string -> config -> t Lwt.t
+val create : process:Eio.Process.t -> state_dir:string -> config -> t
 (** [create ~state_dir config] is a runc sandboxing system that keeps state in [state_dir]
     and is configured using [config]. *)

--- a/lib/zfs_store.mli
+++ b/lib/zfs_store.mli
@@ -2,5 +2,5 @@
 
 include S.STORE
 
-val create : pool:string -> t Lwt.t
+val create : process:Eio.Process.t -> pool:string -> t
 (** [create ~pool] is a new store in zfs pool [pool]. *)

--- a/stress/dune
+++ b/stress/dune
@@ -1,6 +1,6 @@
 ; No-op test to attach stress.exe to the obuilder package
-(test
- (name stress)
- (libraries obuilder cmdliner fmt.tty)
- (package obuilder)
- (action (progn)))
+; (test
+;  (name stress)
+;  (libraries obuilder cmdliner fmt.tty)
+;  (package obuilder)
+;  (action (progn)))

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -55,7 +55,7 @@ module Test(Store : S.STORE) = struct
     assert (Store.result t "fail" = None);
     Lwt.return_unit
 
-  let test_cache t =
+  let test_cache ~sw ~process t =
     let uid = Unix.getuid () in
     let gid = Unix.getgid () in
     let user = { Spec.uid = 123; gid = 456 } in
@@ -67,7 +67,7 @@ module Test(Store : S.STORE) = struct
     assert ((Unix.lstat c).Unix.st_uid = 123);
     assert ((Unix.lstat c).Unix.st_gid = 456);
     let user = { Spec.uid; gid } in
-    Os.exec ["sudo"; "chown"; Printf.sprintf "%d:%d" uid gid; "--"; c] >>= fun () ->
+    Os.exec ~sw ~process ["sudo"; "chown"; Printf.sprintf "%d:%d" uid gid; "--"; c];
     assert (Sys.readdir c = [| |]);
     write ~path:(c / "data") "v1" >>= fun () ->
     r () >>= fun () ->
@@ -209,12 +209,12 @@ module Test(Store : S.STORE) = struct
     aux ()
 end
 
-let stress spec conf =
+let stress ~sw ~process spec conf =
   Lwt_main.run begin
     spec >>= fun (Store_spec.Store ((module Store), store)) ->
     let module T = Test(Store) in
     T.test_store store >>= fun () ->
-    T.test_cache store >>= fun () ->
+    T.test_cache ~sw ~process store >>= fun () ->
     T.stress_builds store conf >>= fun () ->
     T.prune store conf
   end

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -32,8 +32,8 @@ module Test(Store : S.STORE) = struct
   let test_store t =
     assert (Store.result t "unknown" = None);
     (* Build without a base *)
-    Store.delete t "base" >>= fun () ->
-    Store.build t ~id:"base" (fun tmpdir -> write ~path:(tmpdir / "output") "ok" >|= Result.ok) >>= fun r ->
+    Store.delete t "base";
+    let r = Store.build t ~id:"base" (fun tmpdir -> write ~path:(tmpdir / "output") "ok" >|= Result.ok) in
     assert (r = Ok ());
     assert_output "ok" t "base";
     (* Build with a base *)

--- a/test/dune
+++ b/test/dune
@@ -2,6 +2,6 @@
   (name test)
   (package obuilder)
   (deps base.tar)
-  (libraries alcotest-lwt obuilder str logs.fmt))
+  (libraries eio eio_main alcotest-lwt obuilder str logs.fmt))
 
 (dirs :standard \ test1)

--- a/test/mock_exec.ml
+++ b/test/mock_exec.ml
@@ -1,5 +1,3 @@
-open Lwt.Infix
-
 module Os = Obuilder.Os
 
 let ( / ) = Filename.concat
@@ -11,17 +9,14 @@ let next_container_id = ref 0
 let base_tar =
   let mydir = Sys.getcwd () in
   Lwt_main.run (Lwt_io.(with_file ~mode:input) (mydir / "base.tar") Lwt_io.read)
-  |> Bytes.of_string
+  |> Cstruct.of_string
 
-let with_fd x f =
-  match x with
-  | `FD_move_safely fd ->
-    let copy = Unix.dup ~cloexec:true fd.Os.raw in
-    Os.close fd;
-    Lwt.finalize
-      (fun () -> f copy)
-      (fun () -> Unix.close copy; Lwt.return ())
-  | _ -> failwith "Unsupported mock FD redirection"
+let with_fd ~sw (fd : Eio.Flow.sink) f =
+  let copy = Eio_unix.dup ~sw (fd :> Eio.Generic.t) in
+  Option.iter Unix.close (Eio_unix.FD.peek_opt fd);
+  Fun.protect
+    (fun () -> f copy)
+    ~finally:(fun () -> Eio.Flow.close copy)
 
 let docker_create ?stdout base =
   with_fd (Option.get stdout) @@ fun stdout ->
@@ -29,9 +24,9 @@ let docker_create ?stdout base =
   incr next_container_id;
   let rec aux i =
     let len = String.length id - i in
-    if len = 0 then Lwt_result.return 0
+    if len = 0 then Ok 0
     else (
-      let sent = Unix.single_write_substring stdout id i len in
+      let sent = Unix.single_write_substring (stdout#unix_fd `Peek) id i len in
       aux (i + sent)
     )
   in
@@ -39,48 +34,41 @@ let docker_create ?stdout base =
 
 let docker_export ?stdout _id =
   with_fd (Option.get stdout) @@ fun stdout ->
-  let stdout = Lwt_unix.of_unix_file_descr stdout in
-  Os.write_all stdout base_tar 0 (Bytes.length base_tar) >|= fun () ->
+  Os.write_all stdout base_tar 0 (Cstruct.length base_tar);
   Ok 0
 
 let docker_inspect ?stdout _id =
   with_fd (Option.get stdout) @@ fun stdout ->
-  let stdout = Lwt_unix.of_unix_file_descr stdout in
-  let msg = Bytes.of_string "PATH=/usr/bin:/usr/local/bin" in
-  Os.write_all stdout msg 0 (Bytes.length msg) >|= fun () ->
+  let msg = Cstruct.of_string "PATH=/usr/bin:/usr/local/bin" in
+  Os.write_all stdout msg 0 (Cstruct.length msg);
   Ok 0
 
-let exec_docker ?stdout = function
-  | ["create"; "--"; base] -> docker_create ?stdout base
-  | ["export"; "--"; id] -> docker_export ?stdout id
-  | ["image"; "inspect"; "--format"; {|{{range .Config.Env}}{{print . "\x00"}}{{end}}|}; "--"; base] -> docker_inspect ?stdout base
-  | ["rm"; "--"; id] -> Fmt.pr "docker rm %S@." id; Lwt_result.return 0
+let exec_docker ~sw ?stdout = function
+  | ["create"; "--"; base] -> docker_create ~sw ?stdout base
+  | ["export"; "--"; id] -> docker_export ~sw ?stdout id
+  | ["image"; "inspect"; "--format"; {|{{range .Config.Env}}{{print . "\x00"}}{{end}}|}; "--"; base] -> docker_inspect ~sw ?stdout base
+  | ["rm"; "--"; id] -> Fmt.pr "docker rm %S@." id; Ok 0
   | x -> Fmt.failwith "Unknown mock docker command %a" Fmt.(Dump.list string) x
 
 let mkdir = function
-  | ["--mode=755"; "--"; path] -> Unix.mkdir path 0o755; Lwt_result.return 0
+  | ["--mode=755"; "--"; path] -> Unix.mkdir path 0o755; Ok 0
   | x -> Fmt.failwith "Unexpected mkdir %a" Fmt.(Dump.list string) x
 
 let closing redir fn =
-  Lwt.finalize fn
-    (fun () ->
-       begin match redir with
-         | Some (`FD_move_safely fd) -> Os.ensure_closed_unix fd
-         | _ -> ()
-       end;
-       Lwt.return_unit
-    )
+  Fun.protect fn
+    ~finally:(fun () -> match redir with Some fd -> Os.ensure_closed_unix fd | _ -> ())
 
-let exec ?cwd ?stdin ?stdout ?stderr ~pp cmd =
+let exec ?cwd ?stdin ?stdout ?stderr ~sw ~process ~pp cmd =
   closing stdin @@ fun () ->
   closing stdout @@ fun () ->
   closing stderr @@ fun () ->
   match cmd with
   | ("", argv) ->
-    Fmt.pr "exec: %a@." Fmt.(Dump.array string) argv;
-    begin match Array.to_list argv with
-      | "docker" :: args -> exec_docker ?stdout args
-      | "sudo" :: ("tar" :: _ as tar) -> Os.default_exec ?cwd ?stdin ?stdout ~pp ("", Array.of_list tar)
+    Fmt.pr "exec: %a@." Fmt.(Dump.list string) argv;
+    begin match argv with
+      | "docker" :: args -> exec_docker ~sw ?stdout args
+      | "sudo" :: ("tar" :: _ as tar) ->
+        Os.default_exec ~sw ~process ?stdin ?stdout ?cwd ~pp ("tar", tar)
       | "sudo" :: "mkdir" :: args
       | "mkdir" :: args -> mkdir args
       | x -> Fmt.failwith "Unknown mock command %a" Fmt.(Dump.list string) x

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -1,24 +1,26 @@
+open Eio
+
 type t = {
   expect :
-    (cancelled:unit Lwt.t ->
-     ?stdin:Obuilder.Os.unix_fd ->
+    (cancelled:unit Promise.t ->
+     ?stdin:<Eio.Flow.source; Eio_unix.unix_fd> ->
      log:Obuilder.Build_log.t ->
      Obuilder.Config.t ->
      string ->
-     (unit, [`Msg of string | `Cancelled]) Lwt_result.t) Queue.t;
+     (unit, [`Msg of string | `Cancelled]) result Promise.t) Queue.t;
 }
 
 let expect t x = Queue.add x t.expect
 
-let run ~cancelled ?stdin ~log t (config:Obuilder.Config.t) dir =
+let run ~sw:_ ~dir:_ ~process:_ ~cancelled ?stdin ~log t (config:Obuilder.Config.t) dir =
   match Queue.take_opt t.expect with
   | None -> Fmt.failwith "Unexpected sandbox execution: %a" Fmt.(Dump.list string) config.argv
   | Some fn ->
-    Lwt.catch
-      (fun () -> fn ~cancelled ?stdin ~log config dir)
-      (function
-        | Failure ex -> Lwt_result.fail (`Msg ex)
-        | ex -> Lwt_result.fail (`Msg (Printexc.to_string ex))
-      )
+    try
+      Promise.await @@ fn ~cancelled ?stdin ~log config dir
+    with
+      | Failure ex -> Error (`Msg ex)
+      | ex -> Error (`Msg (Printexc.to_string ex))
+      
 
 let create () = { expect = Queue.create () }

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -22,5 +22,6 @@ let run ~sw:_ ~dir:_ ~process:_ ~cancelled ?stdin ~log t (config:Obuilder.Config
       | Failure ex -> Error (`Msg ex)
       | ex -> Error (`Msg (Printexc.to_string ex))
       
+      
 
 let create () = { expect = Queue.create () }

--- a/test/mock_sandbox.mli
+++ b/test/mock_sandbox.mli
@@ -2,10 +2,10 @@ include Obuilder.S.SANDBOX
 
 val create : unit -> t
 val expect :
-  t -> (cancelled:unit Lwt.t ->
-        ?stdin:Obuilder.Os.unix_fd ->
+  t -> (cancelled:unit Eio.Promise.t ->
+        ?stdin:<Eio.Flow.source; Eio_unix.unix_fd> ->
         log:Obuilder.Build_log.t ->
         Obuilder.Config.t ->
         string ->
-        (unit, [`Msg of string | `Cancelled]) Lwt_result.t) ->
+        (unit, [`Msg of string | `Cancelled]) result Eio.Promise.t) ->
   unit

--- a/test/mock_store.mli
+++ b/test/mock_store.mli
@@ -1,13 +1,13 @@
 include Obuilder.S.STORE
 
-val with_store : (t -> 'a Lwt.t) -> 'a Lwt.t
+val with_store : dir:Eio.Dir.t -> process:Eio.Process.t -> (t -> 'a) -> 'a
 (** [with_store t fn] runs [fn] with a fresh store, which is deleted when [fn] returns. *)
 
 val path : t -> Obuilder.S.id -> string
 (** [path t id] is the path that [id] is or would be stored at. *)
 
-val find : output:string -> t -> Obuilder.S.id option Lwt.t
+val find : dir:Eio.Dir.t -> output:string -> t -> Obuilder.S.id option
 (** [find ~output t] returns the ID of a build whose "rootfs/output" file contains [output], if any. *)
 
-val delay_store : (unit Lwt.t) ref
+val delay_store : (unit Eio.Promise.t) ref 
 (** Wait for this to resolve after a build function finishes, but before handling the result. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -715,12 +715,12 @@ let () =
         Alcotest.test_case "Docker"   `Quick test_docker;
       ];
       "build", [
-        (* test_case "Simple"     `Quick test_simple;
+        test_case "Simple"     `Quick test_simple;
         test_case "Prune"      `Quick test_prune;
         test_case "Concurrent" `Quick test_concurrent;
         test_case "Concurrent failure" `Quick test_concurrent_failure;
         test_case "Concurrent failure 2" `Quick test_concurrent_failure_2;
-        test_case "Cancel"     `Quick test_cancel; *)
+        test_case "Cancel"     `Quick test_cancel;
         test_case "Cancel 2"   `Quick test_cancel_2;
         test_case "Cancel 3"   `Quick test_cancel_3;
         (* test_case "Cancel 4"   `Quick test_cancel_4;

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,15 +1,15 @@
-open Lwt.Infix
+open Eio
 open Obuilder
 
 module B = Builder(Mock_store)(Mock_sandbox)(Docker)
 
 let ( / ) = Filename.concat
-let ( >>!= ) = Lwt_result.bind
+let ( >>!= ) = Result.bind
 
 let () =
   Logs.(set_level ~all:true (Some Info));
   Logs.set_reporter @@ Logs_fmt.reporter ();
-  Os.lwt_process_exec := Mock_exec.exec
+  Os.eio_process_exec := Mock_exec.exec
 
 let build_result =
   Alcotest.of_pp @@ fun f x ->
@@ -18,19 +18,22 @@ let build_result =
   | Error `Cancelled -> Fmt.string f "Cancelled"
   | Ok id -> Fmt.string f id
 
-let get store path id =
+let get ~dir store path id =
   let result = Mock_store.path store id in
-  Lwt_io.(with_file ~mode:input) (result / "rootfs" / path) Lwt_io.read >|= Result.ok
+  Dir.load dir (result / "rootfs" / path) |> Result.ok
 
-let with_config fn =
-  Mock_store.with_store @@ fun store ->
+let with_config ~dir ~process fn =
+  Mock_store.with_store ~dir ~process @@ fun store ->
   let sandbox = Mock_sandbox.create () in
-  let builder = B.v ~store ~sandbox in
+  let builder = B.v ~store ~sandbox ~dir ~process in
   let src_dir = Mock_store.state_dir store / "src" in
   Os.ensure_dir src_dir;
   fn ~src_dir ~store ~sandbox ~builder
 
-let mock_op ?(result=Lwt_result.return ()) ?(delay_store=Lwt.return_unit) ?cancel ?output () =
+let alread_resolved = Eio.Promise.create_resolved ()
+let ok_promise = Eio.Promise.create_resolved (Ok ())
+
+let mock_op ~dir:dir_cap ?(result=ok_promise) ?(delay_store=alread_resolved) ?cancel ?output () =
   fun ~cancelled ?stdin:_ ~log (config:Obuilder.Config.t) dir ->
   Mock_store.delay_store := delay_store;
   let cmd =
@@ -38,30 +41,35 @@ let mock_op ?(result=Lwt_result.return ()) ?(delay_store=Lwt.return_unit) ?cance
     | ["/bin/bash"; "-c"; cmd] -> cmd
     | x -> Fmt.str "%a" Fmt.(Dump.list string) x
   in
-  Build_log.printf log "%s@." cmd >>= fun () ->
-  cancel |> Option.iter (fun cancel ->
-      Lwt.on_termination cancelled (fun () -> Lwt.wakeup cancel (Error `Cancelled))
+  Build_log.printf log "%s@." cmd;
+  cancel |> Option.iter (fun (sw, cancel) ->
+    Fiber.fork ~sw (fun () ->
+       ignore (Promise.await cancelled);
+       Promise.resolve cancel (Error `Cancelled)
+      )
     );
   let rootfs = dir / "rootfs" in
+  let create = `Or_truncate 0o666 in
   begin match output with
-    | Some (`Constant v) -> Lwt_io.(with_file ~mode:output) (rootfs / "output") (fun ch -> Lwt_io.write ch v)
+    | Some (`Constant v) -> 
+      Dir.save ~create dir_cap (rootfs / "output") v
     | Some (`Append (v, src)) ->
-      Lwt_io.(with_file ~mode:input) (rootfs / src) Lwt_io.read >>= fun src ->
-      Lwt_io.(with_file ~mode:output) (rootfs / "output") (fun ch -> Lwt_io.write ch (src ^ v))
+      let src = Dir.load dir_cap (rootfs / src) in
+      Dir.save ~create dir_cap (rootfs / "output") (src ^ v)
     | Some `Append_cmd ->
-      Lwt_io.(with_file ~mode:input) (rootfs / "output") Lwt_io.read >>= fun src ->
-      Lwt_io.(with_file ~mode:output) (rootfs / "output") (fun ch -> Lwt_io.write ch (src ^ cmd))
-    | None -> Lwt.return_unit
-  end >>= fun () ->
+      let src = Dir.load dir_cap (rootfs / "output") in
+      Dir.save ~create dir_cap (rootfs / "output") (src ^ cmd)
+    | None -> ()
+  end;
   result
 
-let test_simple _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_simple ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let log = Log.create "b" in
-  let context = Context.v ~src_dir ~log:(Log.add log) () in
+  let context = Context.v ~switch ~src_dir ~log:(Log.add log) () in
   let spec = Spec.(stage ~from:"base" [ run "Append" ]) in
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
-  B.build builder context spec >>!= get store "output" >>= fun result ->
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Append ("runner", "base-id")) ());
+  let result = B.build builder context spec >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
   Log.check "Check log"
     {|(from base)
@@ -72,7 +80,7 @@ let test_simple _switch () =
      |} log;
   (* Check result is cached *)
   Log.clear log;
-  B.build builder context spec >>!= get store "output" >>= fun result ->
+  let result = B.build builder context spec >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Final result cached" (Ok "base-distro\nrunner") result;
   Log.check "Check cached log"
     {|(from base)
@@ -80,17 +88,16 @@ let test_simple _switch () =
       /: (run (shell Append))
       Append
       ;---> using .* from cache
-     |} log;
-  Lwt.return_unit
+     |} log
 
-let test_prune _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_prune ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let start = Unix.(gettimeofday () |> gmtime) in
   let log = Log.create "b" in
-  let context = Context.v ~src_dir ~log:(Log.add log) () in
+  let context = Context.v ~switch ~src_dir ~log:(Log.add log) () in
   let spec = Spec.(stage ~from:"base" [ run "Append" ]) in
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
-  B.build builder context spec >>!= get store "output" >>= fun result ->
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Append ("runner", "base-id")) ());
+  let result = B.build builder context spec >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
   Log.check "Check log"
     {|(from base)
@@ -100,34 +107,36 @@ let test_prune _switch () =
       ;---> saved as .*
      |} log;
   let log id = Logs.info (fun f -> f "Deleting %S" id) in
-  B.prune ~log builder ~before:start 10 >>= fun n ->
+  let n = B.prune ~log builder ~before:start 10 in
   Alcotest.(check int) "Nothing before start time" 0 n;
   let end_time = Unix.(gettimeofday () +. 60.0 |> gmtime) in
-  B.prune ~log builder ~before:end_time 10 >>= fun n ->
-  Alcotest.(check int) "Prune" 2 n;
-  Lwt.return_unit
+  let n = B.prune ~log builder ~before:end_time 10 in
+  Alcotest.(check int) "Prune" 2 n
 
 (* Two builds, [A;B] and [A;C] are started together. The [A] command is only run once,
    with the log visible to both while the build is still in progress. *)
-let test_concurrent _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_concurrent ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let log1 = Log.create "b1" in
   let log2 = Log.create "b2" in
-  let context1 = Obuilder.Context.v ~log:(Log.add log1) ~src_dir () in
-  let context2 = Obuilder.Context.v ~log:(Log.add log2) ~src_dir () in
+  let context1 = Obuilder.Context.v ~switch ~log:(Log.add log1) ~src_dir () in
+  let context2 = Obuilder.Context.v ~switch ~log:(Log.add log2) ~src_dir () in
   let spec1 = Obuilder.Spec.(stage ~from:"base"[ run "A"; run "B" ]) in
   let spec2 = Obuilder.Spec.(stage ~from:"base"[ run "A"; run "C" ]) in
-  let a, a_done = Lwt.wait () in
-  Mock_sandbox.expect sandbox (mock_op ~result:a ~output:(`Constant "A") ());
-  Mock_sandbox.expect sandbox (mock_op ~output:`Append_cmd ());
-  Mock_sandbox.expect sandbox (mock_op ~output:`Append_cmd ());
-  let b1 = B.build builder context1 spec1 in
-  Log.await log1 "(from base)\n/: (run (shell A))\nA\n" >>= fun () ->
-  let b2 = B.build builder context2 spec2 in
-  Log.await log2 "(from base)\n/: (run (shell A))\nA\n" >>= fun () ->
-  Lwt.wakeup a_done (Ok ());
-  b1 >>!= get store "output" >>= fun b1 ->
-  b2 >>!= get store "output" >>= fun b2 ->
+  let a, a_done = Promise.create () in
+  Mock_sandbox.expect sandbox (mock_op ~dir ~result:a ~output:(`Constant "A") ());
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:`Append_cmd ());
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:`Append_cmd ());
+  Switch.run @@ fun sw ->
+  let b1, set_b1 = Promise.create () in 
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b1 @@ B.build builder context1 spec1);
+  Log.await log1 "(from base)\n/: (run (shell A))\nA\n";
+  let b2, set_b2 = Promise.create () in 
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b2 @@ B.build builder context2 spec2);
+  Log.await log2 "(from base)\n/: (run (shell A))\nA\n";
+  Promise.resolve_ok a_done ();
+  let b1 = Promise.await b1 >>!= get ~dir store "output" in
+  let b2 = Promise.await b2 >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Final result" (Ok "AB") b1;
   Alcotest.(check build_result) "Final result" (Ok "AC") b2;
   Log.check "Check AB log"
@@ -151,27 +160,29 @@ let test_concurrent _switch () =
        C
       ;---> saved as .*
      |}
-    log2;
-  Lwt.return ()
+    log2
 
 (* Two builds, [A;B] and [A;C] are started together. The [A] command fails. *)
-let test_concurrent_failure _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_concurrent_failure ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let log1 = Log.create "b1" in
   let log2 = Log.create "b2" in
-  let context1 = Obuilder.Context.v ~log:(Log.add log1) ~src_dir () in
-  let context2 = Obuilder.Context.v ~log:(Log.add log2) ~src_dir () in
+  let context1 = Obuilder.Context.v ~switch ~log:(Log.add log1) ~src_dir () in
+  let context2 = Obuilder.Context.v ~switch ~log:(Log.add log2) ~src_dir () in
   let spec1 = Obuilder.Spec.(stage ~from:"base" [ run "A"; run "B" ]) in
   let spec2 = Obuilder.Spec.(stage ~from:"base" [ run "A"; run "C" ]) in
-  let a, a_done = Lwt.wait () in
-  Mock_sandbox.expect sandbox (mock_op ~result:a ());
-  let b1 = B.build builder context1 spec1 in
-  Log.await log1 "(from base)\n/: (run (shell A))\nA\n" >>= fun () ->
-  let b2 = B.build builder context2 spec2 in
-  Log.await log2 "(from base)\n/: (run (shell A))\nA\n" >>= fun () ->
-  Lwt.wakeup a_done (Error (`Msg "Mock build failure"));
-  b1 >>!= get store "output" >>= fun b1 ->
-  b2 >>!= get store "output" >>= fun b2 ->
+  let a, a_done = Promise.create () in
+  Mock_sandbox.expect sandbox (mock_op ~dir ~result:a ());
+  Switch.run @@ fun sw ->
+  let b1, set_b1 = Promise.create () in
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b1 @@ B.build builder context1 spec1);
+  Log.await log1 "(from base)\n/: (run (shell A))\nA\n";
+  let b2, set_b2 = Promise.create () in 
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b2 @@ B.build builder context2 spec2);
+  Log.await log2 "(from base)\n/: (run (shell A))\nA\n";
+  Promise.resolve a_done (Error (`Msg "Mock build failure"));
+  let b1 = Promise.await b1 >>!= get ~dir store "output" in
+  let b2 = Promise.await b2 >>!= get ~dir store "output" in
   Alcotest.(check build_result) "B1 result" (Error (`Msg "Mock build failure")) b1;
   Alcotest.(check build_result) "B2 result" (Error (`Msg "Mock build failure")) b2;
   Log.check "Check AB log"
@@ -187,28 +198,30 @@ let test_concurrent_failure _switch () =
        /: (run (shell A))
        A
      |}
-    log2;
-  Lwt.return ()
+    log2
 
 (* Two builds, [A;B] and [A;C] are started together. The [A] command fails
    just as the second build is trying to open the log file. *)
-let test_concurrent_failure_2 _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_concurrent_failure_2 ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let log1 = Log.create "b1" in
   let log2 = Log.create "b2" in
-  let context1 = Obuilder.Context.v ~log:(Log.add log1) ~src_dir () in
-  let context2 = Obuilder.Context.v ~log:(Log.add log2) ~src_dir () in
+  let context1 = Obuilder.Context.v ~switch ~log:(Log.add log1) ~src_dir () in
+  let context2 = Obuilder.Context.v ~switch ~log:(Log.add log2) ~src_dir () in
   let spec1 = Obuilder.Spec.(stage ~from:"base" [ run "A"; run "B" ]) in
   let spec2 = Obuilder.Spec.(stage ~from:"base" [ run "A"; run "C" ]) in
-  let a, a_done = Lwt.wait () in
-  Mock_sandbox.expect sandbox (mock_op ~result:(Lwt_result.fail (`Msg "Mock build failure")) ~delay_store:a ());
-  let b1 = B.build builder context1 spec1 in
-  Log.await log1 "(from base)\n/: (run (shell A))\nA\n" >>= fun () ->
-  let b2 = B.build builder context2 spec2 in
-  Log.await log2 "(from base)\n/: (run (shell A))\nA\n" >>= fun () ->
-  Lwt.wakeup a_done ();
-  b1 >>!= get store "output" >>= fun b1 ->
-  b2 >>!= get store "output" >>= fun b2 ->
+  let a, a_done = Promise.create () in
+  Mock_sandbox.expect sandbox (mock_op ~dir ~result:(Promise.create_resolved (Error (`Msg "Mock build failure"))) ~delay_store:a ());
+  Switch.run @@ fun sw ->
+  let b1, set_b1 = Promise.create () in
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b1 @@ B.build builder context1 spec1);
+  Log.await log1 "(from base)\n/: (run (shell A))\nA\n";
+  let b2, set_b2 = Promise.create () in
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b2 @@ B.build builder context2 spec2);
+  Log.await log2 "(from base)\n/: (run (shell A))\nA\n";
+  Promise.resolve a_done ();
+  let b1 = Promise.await b1 >>!= get ~dir store "output" in
+  let b2 = Promise.await b2 >>!= get ~dir store "output" in
   Alcotest.(check build_result) "B1 result" (Error (`Msg "Mock build failure")) b1;
   Alcotest.(check build_result) "B2 result" (Error (`Msg "Mock build failure")) b2;
   Log.check "Check AB log"
@@ -224,36 +237,35 @@ let test_concurrent_failure_2 _switch () =
        /: (run (shell A))
        A
      |}
-    log2;
-  Lwt.return ()
+    log2
 
-let test_cancel _switch () =
-  with_config @@ fun ~src_dir ~store:_ ~sandbox ~builder ->
+let test_cancel ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store:_ ~sandbox ~builder ->
   let log = Log.create "b" in
-  let switch = Lwt_switch.create () in
+  Switch.run @@ fun sw ->
   let context = Context.v ~switch ~src_dir ~log:(Log.add log) () in
   let spec = Spec.(stage ~from:"base" [ run "Wait" ]) in
-  let r, set_r = Lwt.wait () in
-  Mock_sandbox.expect sandbox (mock_op ~result:r ~cancel:set_r ());
-  let b = B.build builder context spec in
-  Log.await log "(from base)\n/: (run (shell Wait))\nWait\n" >>= fun () ->
-  Lwt_switch.turn_off switch >>= fun () ->
-  b >>= fun result ->
+  let r, set_r = Promise.create () in
+  Mock_sandbox.expect sandbox (mock_op ~dir ~result:r ~cancel:(sw, set_r) ());
+  let b, set_b1 = Promise.create () in
+  Fiber.fork ~sw (fun () -> Promise.resolve set_b1 @@ B.build builder context spec);
+  Log.await log "(from base)\n/: (run (shell Wait))\nWait\n";
+  Switch.fail sw (Failure "cancelled");
+  let result = Promise.await b in
   Alcotest.(check build_result) "Final result" (Error `Cancelled) result;
   Log.check "Check log"
     {|(from base)
       ;---> saved as .*
       /: (run (shell Wait))
       Wait
-     |} log;
-  Lwt.return_unit
+     |} log
 
 (* Two users are sharing a build. One cancels. *)
-let test_cancel_2 _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+(* let test_cancel_2 ~dir ~process _switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let spec = Spec.(stage ~from:"base" [ run "Wait" ]) in
-  let r, set_r = Lwt.wait () in
-  Mock_sandbox.expect sandbox (mock_op ~result:r ~cancel:set_r ~output:(`Constant "ok") ());
+  let r, set_r = Promise.create () in
+  Mock_sandbox.expect sandbox (mock_op ~dir ~result:r ~cancel:set_r ~output:(`Constant "ok") ());
   let log1 = Log.create "b1" in
   let log2 = Log.create "b2" in
   let switch1 = Lwt_switch.create () in
@@ -261,10 +273,10 @@ let test_cancel_2 _switch () =
   let context1 = Context.v ~switch:switch1 ~src_dir ~log:(Log.add log1) () in
   let context2 = Context.v ~switch:switch2 ~src_dir ~log:(Log.add log2) () in
   let b1 = B.build builder context1 spec in
-  Log.await log1 "(from base)\n/: (run (shell Wait))\nWait\n" >>= fun () ->
+  Log.await log1 "(from base)\n/: (run (shell Wait))\nWait\n";
   let b2 = B.build builder context2 spec in
-  Log.await log2 "(from base)\n/: (run (shell Wait))\nWait\n" >>= fun () ->
-  Lwt_switch.turn_off switch1 >>= fun () ->
+  Log.await log2 "(from base)\n/: (run (shell Wait))\nWait\n";
+  (* Lwt_switch.turn_off switch1; *)
   b1 >>= fun result1 ->
   Alcotest.(check build_result) "User 1 result" (Error `Cancelled) result1;
   Log.check "Check log"
@@ -273,7 +285,7 @@ let test_cancel_2 _switch () =
       /: (run (shell Wait))
       Wait
      |} log1;
-  Lwt.wakeup set_r (Ok ());
+  Promise.resolve set_r (Ok ());
   b2 >>!= get store "output" >>= fun result2 ->
   Alcotest.(check build_result) "Final result" (Ok "ok") result2;
   Log.check "Check log"
@@ -386,37 +398,37 @@ let test_cancel_5 _switch () =
   Lwt.wakeup set_delay ();
   b2 >>!= get store "output" >>= fun result1 ->
   Alcotest.(check build_result) "User 2 result" (Ok "ok") result1;
-  Lwt.return_unit
+  Lwt.return_unit *)
 
-let test_delete _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+(* let test_delete ~dir ~process _switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let spec = Spec.(stage ~from:"base" [ run "A"; run "B" ]) in
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Constant "A") ());
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Constant "B") ());
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Constant "A") ());
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Constant "B") ());
   let log1 = Log.create "b1" in
   let switch1 = Lwt_switch.create () in
   let context1 = Context.v ~switch:switch1 ~src_dir ~log:(Log.add log1) () in
   let b1 = B.build builder context1 spec in
-  b1 >>!= get store "output" >>= fun result1 ->
+  let result1 = b1 >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Build 1 result" (Ok "B") result1;
   (* Remove A *)
-  Mock_store.find ~output:"A" store >>= fun id ->
+  let id = Mock_store.find ~dir ~output:"A" store in
   let id = Option.get id in
   let log = ref [] in
-  B.delete ~log:(fun x -> log := x :: !log) builder id >>= fun () ->
+  B.delete ~log:(fun x -> log := x :: !log) builder id;
   Alcotest.(check int) "Deleted 2 items" 2 (List.length !log);
   (* Check rebuild works *)
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Constant "A") ());
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Constant "B") ());
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Constant "A") ());
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Constant "B") ());
   let log2 = Log.create "b2" in
   let switch2 = Lwt_switch.create () in
   let context2 = Context.v ~switch:switch2 ~src_dir ~log:(Log.add log2) () in
   let b2 = B.build builder context2 spec in
-  b2 >>!= get store "output" >>= fun result2 ->
+  let result2 = b2 >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Build 2 result" (Ok "B") result2;
-  Lwt.return_unit
+  Lwt.return_unit *)
 
-let test_tar_long_filename _switch () =
+(* let test_tar_long_filename _switch () =
   let do_test length =
     Logs.info (fun m -> m "Test copy length %d " length);
     Lwt_io.with_temp_dir ~prefix:"test-copy-src-" @@ fun src_dir ->
@@ -439,7 +451,7 @@ let test_tar_long_filename _switch () =
   in
   do_test 80 >>= fun () ->
   do_test 160 >>= fun () ->
-  do_test 240
+  do_test 240 *)
 
 let sexp = Alcotest.of_pp Sexplib.Sexp.pp_hum
 
@@ -590,7 +602,7 @@ let manifest =
     (Alcotest.of_pp (fun f (`Msg m) -> Fmt.string f m))
 
 (* Test copy step. *)
-let test_copy _switch () =
+(* let test_copy _switch () =
   Lwt_io.with_temp_dir ~prefix:"test-copy-" @@ fun src_dir ->
   Lwt_io.(with_file ~mode:output) (src_dir / "file") (fun ch -> Lwt_io.write ch "file-data") >>= fun () ->
   (* Files *)
@@ -630,7 +642,7 @@ let test_copy _switch () =
   Alcotest.(check manifest) "Tree"
     (Ok (`Dir ("dir1", [`Dir ("dir1/dir2", [`File ("dir1/dir2/file2", f2hash)])])))
   @@ Manifest.generate ~exclude:[] ~src_dir "dir1";
-  Lwt.return_unit
+  Lwt.return_unit *)
 
 let test_cache_id () =
   let check expected id =
@@ -646,23 +658,23 @@ let test_cache_id () =
   check "c-foo%3abar" "foo:bar";
   check "c-Az09-id.foo_orig" "Az09-id.foo_orig"
 
-let test_secrets_not_provided _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_secrets_not_provided ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let log = Log.create "b" in
-  let context = Context.v ~src_dir ~log:(Log.add log) () in
+  let context = Context.v ~switch ~src_dir ~log:(Log.add log) () in
   let spec = Spec.(stage ~from:"base" [ run ~secrets:[Secret.v ~target:"/run/secrets/test" "test"] "Append" ]) in
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
-  B.build builder context spec >>!= get store "output" >>= fun result ->
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Append ("runner", "base-id")) ());
+  let result = B.build builder context spec >>!= get store ~dir "output" in
   Alcotest.(check build_result) "Final result" (Error (`Msg "Couldn't find value for requested secret 'test'")) result;
   Lwt.return_unit
 
-let test_secrets_simple _switch () =
-  with_config @@ fun ~src_dir ~store ~sandbox ~builder ->
+let test_secrets_simple ~dir ~process switch () =
+  with_config ~dir ~process @@ fun ~src_dir ~store ~sandbox ~builder ->
   let log = Log.create "b" in
-  let context = Context.v ~src_dir ~log:(Log.add log) ~secrets:["test", "top secret value"; "test2", ""] () in
+  let context = Context.v ~switch ~src_dir ~log:(Log.add log) ~secrets:["test", "top secret value"; "test2", ""] () in
   let spec = Spec.(stage ~from:"base" [ run ~secrets:[Secret.v ~target:"/testsecret" "test"; Secret.v "test2"] "Append" ]) in
-  Mock_sandbox.expect sandbox (mock_op ~output:(`Append ("runner", "base-id")) ());
-  B.build builder context spec >>!= get store "output" >>= fun result ->
+  Mock_sandbox.expect sandbox (mock_op ~dir ~output:(`Append ("runner", "base-id")) ());
+  let result = B.build builder context spec >>!= get ~dir store "output" in
   Alcotest.(check build_result) "Final result" (Ok "base-distro\nrunner") result;
   Log.check "Check b log"
     {| (from base)
@@ -672,17 +684,21 @@ let test_secrets_simple _switch () =
          Append
         ;---> saved as .*
        |}
-    log;
-  Lwt.return_unit
+    log
 
 let () =
-  let open Alcotest_lwt in
-  Lwt_main.run begin
-    run "OBuilder" [
+  Eio_main.run @@ fun env ->
+  let dir = Eio.Stdenv.fs env in
+  let process = Eio.Stdenv.process env in
+  let test_case s m fn =
+    let switch = Lwt_switch.create () in
+    Alcotest.test_case s m (fn ~dir ~process switch)
+  in
+    Alcotest.run "OBuilder" [
       "spec", [
-        test_case_sync "Sexp"     `Quick test_sexp;
-        test_case_sync "Cache ID" `Quick test_cache_id;
-        test_case_sync "Docker"   `Quick test_docker;
+        Alcotest.test_case "Sexp"     `Quick test_sexp;
+        Alcotest.test_case "Cache ID" `Quick test_cache_id;
+        Alcotest.test_case "Docker"   `Quick test_docker;
       ];
       "build", [
         test_case "Simple"     `Quick test_simple;
@@ -690,8 +706,9 @@ let () =
         test_case "Concurrent" `Quick test_concurrent;
         test_case "Concurrent failure" `Quick test_concurrent_failure;
         test_case "Concurrent failure 2" `Quick test_concurrent_failure_2;
-        test_case "Cancel"     `Quick test_cancel;
-        test_case "Cancel 2"   `Quick test_cancel_2;
+        (* test_case "Cancel"     `Quick test_cancel; *)
+      ]
+        (* test_case "Cancel 2"   `Quick test_cancel_2;
         test_case "Cancel 3"   `Quick test_cancel_3;
         test_case "Cancel 4"   `Quick test_cancel_4;
         test_case "Cancel 5"   `Quick test_cancel_5;
@@ -706,6 +723,5 @@ let () =
       ];
       "manifest", [
         test_case "Copy"       `Quick test_copy;
-      ];
+      ]; *)
     ]
-  end


### PR DESCRIPTION
This is a _very experimental_ PR/branch that starts trying to port OBuilder to Eio. As part of some other work I wanted to start tackling https://github.com/ocaml-multicore/eio/issues/126 so I was looking for a good candidate that made heavy use of subprocesses and redirections! 

This branch is currently building with this branch of Eio: https://github.com/patricoferris/eioio/tree/processes

The trickiest part at the moment seems to be how to handle cancellation correctly. I was thinking of maybe just having a global switch that's passes in via `Build.build` that everything uses to spawn fibers etc. and that can be the switch that is cancelled if the user does -- any thoughts on this @talex5 ?