### PR TITLE
Expose `Rsync_store` module

### DIFF
--- a/lib/obuilder.ml
+++ b/lib/obuilder.ml
@@ -10,6 +10,7 @@ module Context = Build.Context
 
 module Btrfs_store = Btrfs_store
 module Zfs_store = Zfs_store
+module Rsync_store = Rsync_store
 module Store_spec = Store_spec
 
 (** {2 Fetchers} *)


### PR DESCRIPTION
This is required or users of the library won't be able to create/configure a rsync store.
Probably an oversight from #102?