### PR TITLE
Add support for Docker/Windows spec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.cmd   text eol=crlf
 *.bash  text eol=lf
 *.sh    text eol=lf
+test/test.ml    text eol=lf

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The initial filesystem snapshot is `BASE`. `run` and `copy` operations create ne
 The initial context is supplied by the user (see [build.mli](lib/build.mli) for details).
 By default:
 - The environment is taken from the Docker configuration of `BASE`.
-- The user is `(uid 0) (gid 0)`.
+- The user is `(uid 0) (gid 0)` on Linux, `(name ContainerAdministrator)` on Windows.
 - The workdir is `/`.
 - The shell is `/bin/bash -c`.
 
@@ -268,6 +268,7 @@ Notes:
 
 ```sexp
 (user (uid UID) (gid GID))
+(user (name NAME))      ; on Windows
 ```
 
 Example:

--- a/example.windows.spec
+++ b/example.windows.spec
@@ -1,0 +1,64 @@
+; This script builds OBuilder itself using a snapshot of the
+; ocaml/opam:windows-mingw-ocaml-4.14 base image.
+;
+; Run it from the top-level of the OBuilder source tree, e.g.
+;
+;   root=../var
+;   dune exec -- obuilder build --docker-backend="$root" -f example.windows.spec .
+;
+; The result can then be found in the Docker image "obuilder-ROOTID-image-HASH"
+; (where HASH is displayed at the end of the build).
+; The logs can be found in "$root/logs/HASH.log".
+; ROOTID is computed as follows: $(realpath "$(root)" | sha256sum | cut -b -7)
+
+((build dev
+	((from ocaml/opam@sha256:63f5f8207ea61195988d9d49afcc4044bee3183645c58de6959f0864fabd9383)
+	 (workdir /src)
+	 (env OPAM_HASH "74176d75a60a6ec4d90d4178733b1e09f8becc6f") ; Fix the version of opam-repository-mingw we want
+	 (shell /cygwin64/bin/bash.exe --login -c)
+	 (run
+	  (network "nat")
+	  (shell
+	   "cd /home/opam/opam-repository \
+	    && (git cat-file -e $OPAM_HASH || git fetch origin opam2) \
+	    && git reset -q --hard $OPAM_HASH \
+	    && git --no-pager log --no-decorate -n1 --oneline \
+	    && rsync -ar --update --exclude='.git' ./ /cygdrive/c/opam/.opam/repo/default \
+	    && ocaml-env exec --64 -- opam update -u"))
+         ; opam update -u fails because of patch, so I'm overriding the repo with rsync
+	 (shell cmd /S /C)
+	 ; Copy just the opam file first (helps caching)
+	 (copy (src obuilder-spec.opam obuilder.opam) (dst ./))
+	 (run
+	  (network "nat")
+	  (cache (opam-archives (target /opam/.opam/download-cache)))
+	  (shell "ocaml-env exec --64 -- opam pin add -yn ."))
+	 ; Install OS package dependencies
+	 (run
+	  (network "nat")
+	  (cache (opam-archives (target /opam/.opam/download-cache)))
+	  (shell "ocaml-env exec --64 -- opam depext -yu obuilder"))
+	 ; Install OCaml dependencies
+	 (run
+	  (network "nat")
+	  (cache (opam-archives (target /opam/.opam/download-cache)))
+	  (shell "ocaml-env exec --64 -- opam install --deps-only -t obuilder-spec"))
+	 (run
+	  (network "nat")
+	  (cache (opam-archives (target /opam/.opam/download-cache)))
+	  (shell "ocaml-env exec --64 -- opam install --deps-only -t obuilder"))
+	 (copy                                                  ; Copy the rest of the source code
+	  (src .)
+	  (dst /src/)
+	  (exclude .git _build _opam duniverse))
+	 (run (shell "ocaml-env exec --64 -- dune build @install"))))    ; Build
+ ; Now generate a small runtime image with just the resulting binary:
+ (from mcr.microsoft.com/windows/servercore:ltsc2022)
+ (run (shell "mkdir C:\obuilder"))
+ (copy (from (build dev))
+       (src /cygwin64/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libsqlite3-0.dll)
+       (dst /obuilder/libsqlite3-0.dll))
+ (copy (from (build dev))
+       (src /src/_build/default/main.exe)
+       (dst /obuilder/obuilder.exe))
+ (run (shell "/obuilder/obuilder.exe --help")))

--- a/lib/rsync_store.ml
+++ b/lib/rsync_store.ml
@@ -3,7 +3,7 @@
    efficient. *)
 open Lwt.Infix
 
-(* The caching approach (and much of the code) is copied from the btrfs 
+(* The caching approach (and much of the code) is copied from the btrfs
    implementation *)
 type cache = {
   lock : Lwt_mutex.t;
@@ -144,7 +144,10 @@ let cache ~user t name =
   end >>= fun () ->
   (* Create writeable clone. *)
   let gen = cache.gen in
-  let { Obuilder_spec.uid; gid } = user in
+  let { Obuilder_spec.uid; gid } = match user with
+    | `Unix user -> user
+    | `Windows _ -> assert false (* rsync not supported on Windows *)
+  in
   (* rsync --chown not supported by the rsync that macOS ships with *)
   Rsync.copy_children ~src:snapshot ~dst:tmp () >>= fun () ->
   Os.sudo [ "chown"; Printf.sprintf "%d:%d" uid gid; tmp ] >>= fun () ->

--- a/lib/sandbox.runc.ml
+++ b/lib/sandbox.runc.ml
@@ -108,7 +108,9 @@ module Json_config = struct
 
   let make {Config.cwd; argv; hostname; user; env; mounts; network; mount_secrets} t ~config_dir ~results_dir : Yojson.Safe.t =
     let user =
-      let { Obuilder_spec.uid; gid } = user in
+      let { Obuilder_spec.uid; gid } = match user with
+        | `Unix user -> user
+        | `Windows _ -> assert false (* runc not supported on Windows *) in
       `Assoc [
         "uid", `Int uid;
         "gid", `Int gid;

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -89,11 +89,11 @@ end = struct
     else fn ()
 end
 
-let user = { Obuilder_spec.uid = Unix.getuid (); gid = Unix.getgid () }
+let user = `Unix { Obuilder_spec.uid = Unix.getuid (); gid = Unix.getgid () }
 
 module Zfs = struct
   let chown ~user t ds =
-    let { Obuilder_spec.uid; gid } = user in
+    let { Obuilder_spec.uid; gid } = match user with `Unix user -> user | `Windows _ -> assert false in
     Os.sudo ["chown"; strf "%d:%d" uid gid; Dataset.path t ds]
 
   let create t ds =

--- a/lib_spec/docker.ml
+++ b/lib_spec/docker.ml
@@ -2,17 +2,19 @@ type ctx = {
   user : Spec.user;
 }
 
-let default_ctx = {
-  user = Spec.root;
-}
-
 (* Note: could do with some escaping here, but the rules are not clear. *)
 let pp_pair f (k, v) =
   Fmt.pf f "%s=%s" k v
 
-let pp_wrap =
+let pp_escape ~escape =
+  match escape with
+  | '\\' -> Fmt.any " \\@\n    "
+  | '`' -> Fmt.any " `@\n    "
+  | _ -> assert false
+
+let pp_wrap ~escape =
   Fmt.using (String.split_on_char '\n')
-    Fmt.(list ~sep:(any " \\@\n    ") (using String.trim string))
+    Fmt.(list ~sep:(pp_escape ~escape) (using String.trim string))
 
 let pp_cache ~ctx f { Cache.id; target; buildkit_options } =
   let buildkit_options = match ctx.user with
@@ -40,11 +42,14 @@ let pp_mount_secret ~ctx f { Secret.id; target; buildkit_options } =
   in
   Fmt.pf f "%a" Fmt.(list ~sep:(any ",") pp_pair) buildkit_options
 
-let pp_run ~ctx f { Spec.cache; shell; secrets; network = _ } =
+let pp_run ~escape ~ctx f { Spec.cache; shell; secrets; network = _ } =
   Fmt.pf f "RUN %a%a%a"
     Fmt.(list (pp_mount_secret ~ctx ++ const string " ")) secrets
     Fmt.(list (pp_cache ~ctx ++ const string " ")) cache
-    pp_wrap shell
+    (pp_wrap ~escape) shell
+
+let is_root user =
+  user = (Spec.root_windows :> Spec.user) || user = (Spec.root_unix :> Spec.user)
 
 let pp_copy ~ctx f { Spec.from; src; dst; exclude = _ } =
   let from = match from with
@@ -52,7 +57,7 @@ let pp_copy ~ctx f { Spec.from; src; dst; exclude = _ } =
     | `Context -> None
   in
   let chown =
-    if ctx.user = Spec.root then None
+    if is_root ctx.user then None
     else (
       match ctx.user with
       | `Unix { uid; gid } -> Some (Printf.sprintf "%d:%d" uid gid)
@@ -79,31 +84,39 @@ let quote ~escape v =
   Buffer.add_substring buf v !j (len - !j);
   Buffer.contents buf
 
-let pp_op ~buildkit ctx f : Spec.op -> ctx = function
+let pp_op ~buildkit ~escape ctx f : Spec.op -> ctx = function
   | `Comment x                -> Fmt.pf f "# %s" x; ctx
   | `Workdir x                -> Fmt.pf f "WORKDIR %s" x; ctx
   | `Shell xs                 -> Fmt.pf f "SHELL [ %a ]" Fmt.(list ~sep:comma (quote string)) xs; ctx
-  | `Run x when buildkit      -> pp_run ~ctx f x; ctx
-  | `Run x                    -> pp_run ~ctx f { x with cache = []; secrets = []}; ctx
+  | `Run x when buildkit      -> pp_run ~escape ~ctx f x; ctx
+  | `Run x                    -> pp_run ~escape ~ctx f { x with cache = []; secrets = []}; ctx
   | `Copy x                   -> pp_copy ~ctx f x; ctx
   | `User (`Unix { uid; gid } as u) -> Fmt.pf f "USER %d:%d" uid gid; { user = u }
   | `User (`Windows { name } as u) -> Fmt.pf f "USER %s" name; { user = u }
-  | `Env (k, v)               -> Fmt.pf f "ENV %s=\"%s\"" k (quote ~escape:'\\' v); ctx
+  | `Env (k, v)               -> Fmt.pf f "ENV %s=\"%s\"" k (quote ~escape v); ctx
 
-let rec convert ~buildkit f (name, { Spec.child_builds; from; ops }) =
+let rec convert ~buildkit ~escape ~ctx f (name, { Spec.child_builds; from; ops }) =
   child_builds |> List.iter (fun (name, spec) ->
-      convert ~buildkit f (Some name, spec);
+      convert ~buildkit ~escape ~ctx f (Some name, spec);
       Format.pp_print_newline f ();
     );
   Fmt.pf f "@[<h>FROM %s%a@]@." from Fmt.(option (const string " as " ++ string)) name;
   let (_ : ctx) = List.fold_left (fun ctx op ->
       Format.pp_open_hbox f ();
-      let ctx = pp_op ~buildkit ctx f op in
+      let ctx = pp_op ~buildkit ~escape ctx f op in
       Format.pp_close_box f ();
       Format.pp_print_newline f ();
       ctx
-    ) default_ctx ops
+    ) ctx ops
   in ()
 
-let dockerfile_of_spec ~buildkit t =
-  Fmt.str "%a" (convert ~buildkit) (None, t)
+let dockerfile_of_spec ~buildkit ~os t =
+  Fmt.str "%a" (fun f ->
+      match os with
+      | `Windows ->
+        let ctx = { user = (Spec.root_windows :> Spec.user) } in
+        (Fmt.pf f "@[<h>#escape=`@]@.";
+         convert ~buildkit ~escape:'`' ~ctx f)
+      | `Unix ->
+        let ctx = { user = (Spec.root_unix :> Spec.user) } in
+        convert ~buildkit ~escape:'\\' ~ctx f) (None, t)

--- a/lib_spec/docker.mli
+++ b/lib_spec/docker.mli
@@ -1,5 +1,6 @@
-val dockerfile_of_spec : buildkit:bool -> Spec.t -> string
-(** [dockerfile_of_spec x] produces a Dockerfile that aims to be equivalent to [x].
+val dockerfile_of_spec : buildkit:bool -> os:[`Unix | `Windows] -> Spec.t -> string
+(** [dockerfile_of_spec ~buildkit ~os x] produces a Dockerfile
+   that aims to be equivalent to [x].
 
     However, note that:
 
@@ -7,5 +8,7 @@ val dockerfile_of_spec : buildkit:bool -> Spec.t -> string
       you have a suitable ".dockerignore" file.
     - The conversion is not robust against malicious input, as the escaping rules are unclear.
 
-    @param buildkit If true, the extended BuildKit syntax is used to support caches.
-                    If false, caches are ignored. *)
+    @param buildkit If true, the extended BuildKit syntax is used to
+      support caches.  If false, caches are ignored. BuildKit syntax
+      isn't supported on Windows.
+    @param os Use UNIX or Windows syntax and idiosyncrasies. *)

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -178,9 +178,9 @@ let env k v = `Env (k, v)
 let user_unix ~uid ~gid = `User (`Unix { uid; gid })
 let user_windows ~name = `User (`Windows { name })
 
-let root =
-  if Sys.win32 then `Windows { name = "ContainerAdministrator" }
-  else `Unix { uid = 0; gid = 0 }
+let root_unix = `Unix { uid = 0; gid = 0 }
+let root_windows = `Windows { name = "ContainerAdministrator" }
+let root = if Sys.win32 then root_windows else root_unix
 
 let rec pp_no_boxes f : Sexplib.Sexp.t -> unit = function
   | List xs -> Fmt.pf f "(%a)" (Fmt.list ~sep:Fmt.sp pp_no_boxes) xs

--- a/lib_spec/spec.ml
+++ b/lib_spec/spec.ml
@@ -56,8 +56,34 @@ let copy_inlined = function
 let copy_of_sexp x = copy_of_sexp (inflate_record copy_inlined x)
 let sexp_of_copy x = deflate_record copy_inlined (sexp_of_copy x)
 
-type user = { uid : int; gid : int }
-[@@deriving sexp]
+type unix_user = {
+  uid : int;
+  gid : int;
+} [@@deriving sexp]
+
+type windows_user = {
+  name : string;
+} [@@deriving sexp]
+
+type user = [
+  | `Unix of unix_user
+  | `Windows of windows_user
+] [@@deriving sexp]
+
+let user_of_sexp x =
+  let open Sexplib.Sexp in
+  match x with
+  | List [List [Atom "name"; _]] ->
+    `Windows (windows_user_of_sexp x)
+  | List [List [Atom "uid"; _]; List [Atom "gid"; _]] ->
+    `Unix (unix_user_of_sexp x)
+  | x -> Fmt.failwith "Invalid op: %a" Sexplib.Sexp.pp_hum x
+
+let sexp_of_user x : Sexplib.Sexp.t =
+  let x = sexp_of_user x in
+  match x with
+  | List [Atom _os; List args] -> List args
+  | x -> Fmt.failwith "Invalid op: %a" Sexplib.Sexp.pp_hum x
 
 type run = {
   cache : Cache.t list [@sexp.list];
@@ -149,9 +175,12 @@ let shell xs = `Shell xs
 let run ?(cache=[]) ?(network=[]) ?(secrets=[]) fmt = fmt |> Printf.ksprintf (fun x -> `Run { shell = x; cache; network; secrets })
 let copy ?(from=`Context) ?(exclude=[]) src ~dst = `Copy { from; src; dst; exclude }
 let env k v = `Env (k, v)
-let user ~uid ~gid = `User { uid; gid }
+let user_unix ~uid ~gid = `User (`Unix { uid; gid })
+let user_windows ~name = `User (`Windows { name })
 
-let root = { uid = 0; gid = 0 }
+let root =
+  if Sys.win32 then `Windows { name = "ContainerAdministrator" }
+  else `Unix { uid = 0; gid = 0 }
 
 let rec pp_no_boxes f : Sexplib.Sexp.t -> unit = function
   | List xs -> Fmt.pf f "(%a)" (Fmt.list ~sep:Fmt.sp pp_no_boxes) xs

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -53,6 +53,8 @@ val env : string -> string -> op
 val user_unix : uid:int -> gid:int -> op
 val user_windows : name:string -> op
 
+val root_unix : [`Unix of unix_user]
+val root_windows : [`Windows of windows_user]
 val root : user
 
 val pp : t Fmt.t

--- a/lib_spec/spec.mli
+++ b/lib_spec/spec.mli
@@ -5,10 +5,19 @@ type copy = {
   exclude : string list;
 } [@@deriving sexp]
 
-type user = {
+type unix_user = {
   uid : int;
-  gid : int
+  gid : int;
 } [@@deriving sexp]
+
+type windows_user = {
+  name : string;
+} [@@deriving sexp]
+
+type user = [
+  | `Unix of unix_user
+  | `Windows of windows_user
+] [@@deriving sexp]
 
 type run = {
   cache : Cache.t list;
@@ -41,7 +50,8 @@ val shell : string list -> op
 val run : ?cache:Cache.t list -> ?network:string list -> ?secrets:Secret.t list -> ('a, unit, string, op) format4 -> 'a
 val copy : ?from:[`Context | `Build of string] -> ?exclude:string list -> string list -> dst:string -> op
 val env : string -> string -> op
-val user : uid:int -> gid:int -> op
+val user_unix : uid:int -> gid:int -> op
+val user_windows : name:string -> op
 
 val root : user
 

--- a/stress/stress.ml
+++ b/stress/stress.ml
@@ -57,7 +57,7 @@ module Test(Store : S.STORE) = struct
   let test_cache t =
     let uid = Unix.getuid () in
     let gid = Unix.getgid () in
-    let user = { Spec.uid = 123; gid = 456 } in
+    let user = `Unix { Spec.uid = 123; gid = 456 } in
     let id = "c1" in
     (* Create a new cache *)
     Store.delete_cache t id >>= fun x ->
@@ -65,7 +65,7 @@ module Test(Store : S.STORE) = struct
     Store.cache ~user t id >>= fun (c, r) ->
     assert ((Unix.lstat c).Unix.st_uid = 123);
     assert ((Unix.lstat c).Unix.st_gid = 456);
-    let user = { Spec.uid; gid } in
+    let user = `Unix { Spec.uid; gid } in
     Os.exec ["sudo"; "chown"; Printf.sprintf "%d:%d" uid gid; "--"; c] >>= fun () ->
     assert (Sys.readdir c = [| |]);
     write ~path:(c / "data") "v1" >>= fun () ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -429,7 +429,7 @@ let test_tar_long_filename _switch () =
     Lwt_unix.openfile (dst_dir / "out.tar") [Lwt_unix.O_WRONLY; Lwt_unix.O_CREAT] 0
     >>= fun to_untar ->
     let src_manifest = Manifest.generate ~exclude:[] ~src_dir "." |> Result.get_ok in
-    let user = {Spec.uid=1000; gid=1000} in
+    let user = Spec.(`Unix { uid=1000; gid=1000 }) in
     Tar_transfer.send_file
       ~src_dir
       ~src_manifest


### PR DESCRIPTION
The commit setting `safe.directory` shall be removed when our base images start shipping with
- https://github.com/ocurrent/ocaml-dockerfile/pull/108