### PR TITLE
Expose store root and cmdliner term with non-required store

### DIFF
--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -101,6 +101,8 @@ let check_kernel_version () =
   | _ ->
       Fmt.failwith "Could not parse output of 'uname -r' (%S)" kver
 
+let root t = t.root
+
 let create root =
   check_kernel_version () >>= fun () ->
   Os.ensure_dir (root / "result");

--- a/lib/rsync_store.ml
+++ b/lib/rsync_store.ml
@@ -3,7 +3,7 @@
    efficient. *)
 open Lwt.Infix
 
-(* The caching approach (and much of the code) is copied from the btrfs 
+(* The caching approach (and much of the code) is copied from the btrfs
    implementation *)
 type cache = {
   lock : Lwt_mutex.t;
@@ -78,6 +78,8 @@ module Path = struct
 
   let result_tmp t id = t.path / result_tmp_dirname / id
 end
+
+let root t = t.path
 
 let create ~path ?(mode = Copy) () =
   Rsync.create path >>= fun () ->

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -13,6 +13,9 @@ type logger = tag -> string -> unit
 module type STORE = sig
   type t
 
+  val root : t -> string
+  (** [root t] returns the root of the store. *)
+
   val build :
     t -> ?base:id ->
     id:id ->

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -141,6 +141,8 @@ let delete_if_exists t ds mode =
 
 let state_dir t = Dataset.path t Dataset.state
 
+let root t = t.pool
+
 let prefix_and_pool path =
   let pool = Filename.basename path in
   match Filename.chop_suffix_opt ~suffix:pool path with

--- a/test/mock_store.ml
+++ b/test/mock_store.ml
@@ -103,3 +103,5 @@ let cache ~user:_ _t _ = assert false
 let delete_cache _t _ = assert false
 
 let complete_deletes _t = Lwt.return_unit
+
+let root t = t.dir


### PR DESCRIPTION
This allows configuring the OBuilder store fully inside the library and not using the store spec externally. I could add an interface to limit the exposed functions to the type and the cmdliner term.