### PR TITLE
Split GHA tests and teardown local state

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.cmd   text eol=crlf
+*.bash  text eol=lf
+*.sh    text eol=lf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     - cron: 0 1 * * MON
 
 env:
-  RUNC_VERSION: v1.1.3
+  RUNC_VERSION: v1.1.4
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,4 +51,6 @@ jobs:
         run: |
           sudo wget https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 -O /usr/local/bin/runc
 
-      - run: ./.run-gha-tests.sh
+      - run: ./.run-gha-tests.sh btrfs
+      - run: ./.run-gha-tests.sh zfs
+      - run: ./.run-gha-tests.sh rsync

--- a/.run-gha-tests.sh
+++ b/.run-gha-tests.sh
@@ -10,44 +10,78 @@ sudo sh -c "cat > /usr/local/bin/uname" << EOF
 if test "\$1" = '-r'; then
   echo '5.08.0-6-amd64'
 else
-  /usr/bin/uname \$@
+  exec /usr/bin/uname \$@
 fi
 EOF
 sudo chmod a+x /usr/local/bin/uname
 
-dd if=/dev/zero of=/tmp/zfs.img bs=100M count=50
-ZFS_LOOP=$(sudo losetup -f)
-sudo losetup -P "$ZFS_LOOP" /tmp/zfs.img
-sudo zpool create zfs "$ZFS_LOOP"
-
-dd if=/dev/zero of=/tmp/btrfs.img bs=100M count=50
-BTRFS_LOOP=$(sudo losetup -f)
-sudo losetup -P "$BTRFS_LOOP" /tmp/btrfs.img
-sudo mkfs.btrfs -f "$BTRFS_LOOP"
-sudo mkdir /btrfs
-sudo mount -t btrfs "$BTRFS_LOOP" /btrfs
-sudo chown "$(whoami)" /btrfs
-
-sudo mkdir /rsync
-sudo chown "$(whoami)" /rsync
-
 opam exec -- make
-opam exec -- dune exec -- obuilder healthcheck --store=btrfs:/btrfs
-opam exec -- dune exec -- obuilder healthcheck --store=rsync:/rsync
-opam exec -- dune exec -- obuilder healthcheck --store=zfs:zfs
-opam exec -- dune exec -- ./stress/stress.exe --store=btrfs:/btrfs
-opam exec -- dune exec -- ./stress/stress.exe --store=rsync:/rsync
-opam exec -- dune exec -- ./stress/stress.exe --store=zfs:zfs
 
-# Populate the caches from our own GitHub Actions cache
-btrfs subvolume create /btrfs/cache/c-opam-archives
-cp -r ~/.opam/download-cache/* /btrfs/cache/c-opam-archives/
-sudo chown -R 1000:1000 /btrfs/cache/c-opam-archives
+case "$1" in
+    btrfs)
+        dd if=/dev/zero of=/tmp/btrfs.img bs=100M count=50
+        BTRFS_LOOP=$(sudo losetup -f)
+        sudo losetup -P "$BTRFS_LOOP" /tmp/btrfs.img
+        sudo mkfs.btrfs -f "$BTRFS_LOOP"
+        sudo mkdir /btrfs
+        sudo mount -t btrfs "$BTRFS_LOOP" /btrfs
+        sudo chown "$(whoami)" /btrfs
 
-sudo zfs create zfs/cache/c-opam-archives
-sudo cp -r ~/.opam/download-cache/* /zfs/cache/c-opam-archives/
-sudo chown -R 1000:1000 /zfs/cache/c-opam-archives
-sudo zfs snapshot zfs/cache/c-opam-archives@snap
+        opam exec -- dune exec -- obuilder healthcheck --store=btrfs:/btrfs
+        opam exec -- dune exec -- ./stress/stress.exe --store=btrfs:/btrfs
 
-opam exec -- dune exec -- obuilder build -f example.spec . --store=btrfs:/btrfs
-opam exec -- dune exec -- obuilder build -f example.spec . --store=zfs:zfs
+        # Populate the caches from our own GitHub Actions cache
+        btrfs subvolume create /btrfs/cache/c-opam-archives
+        cp -r ~/.opam/download-cache/* /btrfs/cache/c-opam-archives/
+        sudo chown -R 1000:1000 /btrfs/cache/c-opam-archives
+
+        opam exec -- dune exec -- obuilder build -f example.spec . --store=btrfs:/btrfs
+
+        sudo umount /btrfs
+        sudo losetup -d "$BTRFS_LOOP"
+        sudo rm -f /tmp/btrfs.img
+        ;;
+
+    zfs)
+        dd if=/dev/zero of=/tmp/zfs.img bs=100M count=50
+        ZFS_LOOP=$(sudo losetup -f)
+        sudo losetup -P "$ZFS_LOOP" /tmp/zfs.img
+        sudo zpool create zfs "$ZFS_LOOP"
+
+        opam exec -- dune exec -- obuilder healthcheck --store=zfs:zfs
+        opam exec -- dune exec -- ./stress/stress.exe --store=zfs:zfs
+
+        # Populate the caches from our own GitHub Actions cache
+        sudo zfs create zfs/cache/c-opam-archives
+        sudo cp -r ~/.opam/download-cache/* /zfs/cache/c-opam-archives/
+        sudo chown -R 1000:1000 /zfs/cache/c-opam-archives
+        sudo zfs snapshot zfs/cache/c-opam-archives@snap
+
+        opam exec -- dune exec -- obuilder build -f example.spec . --store=zfs:zfs
+
+        sudo zpool destroy zfs
+        sudo losetup -d "$ZFS_LOOP"
+        sudo rm -f /tmp/zfs.img
+        ;;
+
+    rsync)
+        sudo mkdir /rsync
+        sudo chown "$(whoami)" /rsync
+
+        opam exec -- dune exec -- obuilder healthcheck --store=rsync:/rsync
+        opam exec -- dune exec -- ./stress/stress.exe --store=rsync:/rsync
+
+        # Populate the caches from our own GitHub Actions cache
+        sudo mkdir -p /rsync/cache/c-opam-archives
+        sudo cp -r ~/.opam/download-cache/* /rsync/cache/c-opam-archives/
+        sudo chown -R 1000:1000 /rsync/cache/c-opam-archives
+
+        opam exec -- dune exec -- obuilder build -f example.spec . --store=rsync:/rsync
+
+        sudo rm -rf /rsync
+        ;;
+
+    *)
+        printf "Usage: .run-gha-tests.sh [btrfs|rsync|zfs]" >&2
+        exit 1
+esac


### PR DESCRIPTION
> The GH Actions test runs out of disk space, need to split that into smaller tests or cleanup disk space during the test.

_Originally posted by @tmcgilchrist in https://github.com/ocurrent/obuilder/issues/122#issuecomment-1273962129_

I hope this might help, it cleans after each store test. I would be also super nice if someone new how to cache the ppa and zfs install.
      