### PR TITLE
GHA: cache apt packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,12 @@ jobs:
       # The ppa is needed because of https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg5972997.html
       - run: |
           sudo add-apt-repository ppa:jonathonf/zfs && \
-          sudo apt-get --allow-releaseinfo-change update && \
-          sudo apt-get install -y btrfs-progs zfs-dkms zfsutils-linux
+          sudo apt-get --allow-releaseinfo-change update
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: btrfs-progs zfs-dkms zfsutils-linux
+          version: 1
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,4 +57,39 @@ jobs:
 
       - run: ./.run-gha-tests.sh btrfs
       - run: ./.run-gha-tests.sh zfs
+
+  build_rsync:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
+      - name: Cache runc
+        id: cache-runc
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/bin/runc
+          key: ${{ env.RUNC_VERSION }}
+
+      - name: Download runc
+        if: steps.cache-runc.outputs.cache-hit != 'true'
+        run: |
+          sudo wget https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 -O /usr/local/bin/runc
+
       - run: ./.run-gha-tests.sh rsync

--- a/.run-gha-tests.sh
+++ b/.run-gha-tests.sh
@@ -46,6 +46,7 @@ case "$1" in
         dd if=/dev/zero of=/tmp/zfs.img bs=100M count=50
         ZFS_LOOP=$(sudo losetup -f)
         sudo losetup -P "$ZFS_LOOP" /tmp/zfs.img
+        sudo /sbin/modprobe zfs
         sudo zpool create zfs "$ZFS_LOOP"
 
         opam exec -- dune exec -- obuilder healthcheck --store=zfs:zfs


### PR DESCRIPTION
This action helps by caching the additional packages we need (btrfs and zfs utils). Downloading and installing them usually takes ~5 mins, I hope we can shave off some time.