### PR TITLE
Rsync and Fuse Issues

### DIFF
--- a/lib/macos.ml
+++ b/lib/macos.ml
@@ -62,6 +62,16 @@ let kill_all_descendants ~pid =
   in
     kill_all pid
 
+let rm ~directory =
+  let pp _ ppf = Fmt.pf ppf "[ RM ]" in
+  let delete = ["rm"; "-r"; directory ] in
+  let* t = sudo_result ~pp:(pp "RM") delete in
+    match t with
+    | Ok () -> Lwt.return ()
+    | Error (`Msg m) ->
+      Log.warn (fun f -> f "Failed to remove %s because %s" directory m);
+      Lwt.return ()
+
 let copy_template ~base ~local =
   let pp s ppf = Fmt.pf ppf "[ %s ]" s in
   sudo_result ~pp:(pp "RSYNC") ["rsync"; "-avq"; base ^ "/"; local]

--- a/lib/rsync_store.ml
+++ b/lib/rsync_store.ml
@@ -101,15 +101,15 @@ let build t ?base ~id fn =
       (fun r ->
       begin match r with
           | Ok () -> Rsync.rename_with_sharing ~mode:t.mode ~base ~src:result_tmp ~dst:result
-          | Error _ -> Lwt.return_unit
+          | Error _ -> Rsync.delete result_tmp
       end >>= fun () ->
       Lwt.return r
       )
-  (fun ex ->
-      Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
-      Rsync.delete result_tmp >>= fun () ->
-      Lwt.fail ex
-  )
+      (fun ex ->
+          Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
+          Rsync.delete result_tmp >>= fun () ->
+          Lwt.fail ex
+      )
 
 let delete t id =
   let path = Path.result t id in


### PR DESCRIPTION
The `rsync` folder `result-tmp` grows uncontrollably, eventually leading to the worker stalling on with the following error:

    2023-01-15 13:22.58       obuilder [INFO] Pruning 0 items (of 100 requested)
    2023-01-15 13:22.58         worker [INFO] OBuilder partition: 7% free after pruning 0 items
    2023-01-15 13:22.58         worker [WARNING] Out of space, but nothing left to prune! (will wait and then retry)

This is caused by the following two considitons:
1) when a job is cancelled, the macOS sandbox does not delete the `result-tmp` folder, and
2) when a job fails, the `rsync` backend does not delete the `result-tmp`.

Furthermore, under normal circumstances, the fuse file system is unmounted between jobs.  This is essential for the Docker health check to be able to _find_ the Docker binary which is installed in `/usr/local`.  However, when a job is cancelled, fuse is not unmounted; therefore, we see the health check fail if it occurs immediately after a cancelled job.