### PR TITLE
Fix use of sudo logic in Os.copy

### DIFF
--- a/lib/os.ml
+++ b/lib/os.ml
@@ -180,14 +180,12 @@ let ensure_dir path =
   | `Present -> ()
   | `Missing -> Unix.mkdir path 0o777
 
-let copy ?(superuser=false) ~src dst =
+let copy ~src dst =
   if Sys.win32 then
     exec ["robocopy"; src; dst; "/MIR"; "/NFL"; "/NDL"; "/NJH"; "/NJS"; "/NC"; "/NS"; "/NP"]
       ~is_success:(fun n -> n = 0 || n = 1)
-  else if superuser then
-    sudo ["cp"; "-a"; "--"; src; dst ]
   else
-    exec ["cp"; "-a"; "--"; src; dst ]
+    sudo ["cp"; "-a"; "--"; src; dst ]
 
 let rm ~directory =
   let pp _ ppf = Fmt.pf ppf "[ RM ]" in


### PR DESCRIPTION
`Os.copy` is not used by anything, but just in case:
- the existing logic "if superuser then sudo copy else copy" obviously needs its condition inverted.
- but then `Os.sudo` can be used directly since it will only use sudo when not superuser.