### PR TITLE
Bump some lower bounds (for Windows fixes)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@
   astring
   (fmt (>= 0.8.9))
   logs
-  (cmdliner (>= 1.1.1))
+  (cmdliner (>= 1.2.0))
   (tar-unix (>= 2.4.0))
   (yojson (>= "1.6.0"))
   sexplib
@@ -54,4 +54,4 @@
   astring
   ppx_deriving
   ppx_sexp_conv
-  (ocaml (>= 4.10.2))))
+  (ocaml (>= 4.14.1))))

--- a/example.spec
+++ b/example.spec
@@ -7,11 +7,11 @@
 ; The result can then be found in /tank/HASH/rootfs/ (where HASH is displayed at the end of the build).
 
 ((build dev
-	((from ocaml/opam@sha256:18fcbeb356957c58cf8f37bc43adcca5683d50163a120d9b322b173428281e61)
+	((from ocaml/opam@sha256:4bfe3c0814b4220417d6ccbbed7eb5486a35d900024745c1f299973e9584e0e5)
 	 (workdir /src)
 	 (user (uid 1000) (gid 1000))                           ; Build as the "opam" user
 	 (run (shell "sudo chown opam /src"))
-	 (env OPAM_HASH "15b381eeae1aa1c8b67b214ce1739344717aae89")
+	 (env OPAM_HASH "eb733d35a0a83a2635d25cd85e905661d145aead")
 	 (run
 	  (network host)
 	  (shell "sudo apt-get --allow-releaseinfo-change update"))

--- a/example.windows.spec
+++ b/example.windows.spec
@@ -12,10 +12,10 @@
 ; ROOTID is computed as follows: $(realpath "$(root)" | sha256sum | cut -b -7)
 
 ((build dev
-	((from ocaml/opam@sha256:487f82160de4275a7219e3e1d676c5a9afddd110d1b146909397be62e8e11bc7)
+	((from ocaml/opam@sha256:4bfe3c0814b4220417d6ccbbed7eb5486a35d900024745c1f299973e9584e0e5)
 	 (workdir /src)
 	 (env OPAM_REPO_MINGW_HASH "921b0eceb594f96c0c7f40bb2676783be4362aeb") ; Fix the version of opam-repository-mingw we want
-	 (env OPAM_HASH "15b381eeae1aa1c8b67b214ce1739344717aae89") ; Fix the version of opam-repository we want
+	 (env OPAM_HASH "eb733d35a0a83a2635d25cd85e905661d145aead") ; Fix the version of opam-repository we want
 	 (shell /cygwin64/bin/bash.exe --login -c)
 	 (run
 	  (network "nat")

--- a/obuilder-spec.opam
+++ b/obuilder-spec.opam
@@ -27,7 +27,7 @@ depends: [
   "astring"
   "ppx_deriving"
   "ppx_sexp_conv"
-  "ocaml" {>= "4.10.2"}
+  "ocaml" {>= "4.14.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/obuilder.opam
+++ b/obuilder.opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "fmt" {>= "0.8.9"}
   "logs"
-  "cmdliner" {>= "1.1.1"}
+  "cmdliner" {>= "1.2.0"}
   "tar-unix" {>= "2.4.0"}
   "yojson" {>= "1.6.0"}
   "sexplib"


### PR DESCRIPTION
cmdliner 1.1 has a bug when viewing OBuilder's manpage.
OCaml 4.14 is better for Windows support, although not really needed for obuilder-spec.