### PR TITLE
Prune one at a time up to the limit

### DIFF
--- a/lib/db_store.ml
+++ b/lib/db_store.ml
@@ -142,10 +142,9 @@ module Make (Raw : S.STORE) = struct
     in
     aux id
 
-  let prune_batch ?(log=ignore) t ~before limit =
-    let items = Dao.lru t.dao ~before limit in
+  let prune_lru ?(log=ignore) t ~before =
+    let items = Dao.lru t.dao ~before 1 in
     let n = List.length items in
-    Log.info (fun f -> f "Pruning %d items (of %d requested)" n limit);
     items |> Lwt_list.iter_s (fun id ->
         log id;
         Raw.delete t.raw id >|= fun () ->
@@ -155,16 +154,18 @@ module Make (Raw : S.STORE) = struct
     Lwt.return n
 
   let prune ?log t ~before limit =
+    Log.info (fun f -> f "Pruning %d items" limit);
     let rec aux acc limit =
       if limit = 0 then Lwt.return acc  (* Pruned everything we wanted to *)
       else (
-        prune_batch ?log t ~before limit >>= function
+        prune_lru ?log t ~before >>= function
         | 0 -> Lwt.return acc           (* Nothing left to prune *)
         | n -> aux (acc + n) (limit - n)
       )
     in
     aux 0 limit >>= fun n ->
     Raw.complete_deletes t.raw >>= fun () ->
+    Log.info (fun f -> f "Pruned %d items" n);
     Lwt.return n
 
   let wrap raw =


### PR DESCRIPTION
When a new obuilder job is accepted by [ocurrent/ocluster](https://github.com/ocurrent/ocluster) the `build` function in [obuilder_build.ml](https://github.com/ocurrent/ocluster/blob/master/worker/obuilder_build.ml) is called.  This checks that there is enough free disk space possibly spawning an asynchronous thread `do_prune` to prune builds before running `Builder.build`.  `do_prune` invokes `Builder.prune` which calls `Store.prune` from `db_store.ml`.  The prune function queries the database to build a list of items ordered by the least recently used and begins deleting them.  The delete operation takes several minutes or longer, however the list of items was evaluated at the start.  It is possible that the build job which was started in parallel with `do_prune` or a subsequent job will use one of the cache steps which is in the list to be pruned.

The workaround proposed here is not perfect.  It minimises the chance that this will happen by checking the last used time for each item as it is deleted.  We will now have one SQL query per item deleted which is less efficient.

The logging has also been updated to show the start and end of the prune operation:
```
2023-04-26 13:59.23       obuilder [INFO] Pruning 10 items
...
2023-04-26 14:00.40       obuilder [INFO] Pruned 10 items
```