### PR TITLE
Search for bash rather than assume it lies in /bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ By default:
 - The environment is taken from the Docker configuration of `BASE`.
 - The user is `(uid 0) (gid 0)` on Linux, `(name ContainerAdministrator)` on Windows.
 - The workdir is `/`, `C:/` on Windows.
-- The shell is `/bin/bash -c`, `C:\Windows\System32\cmd.exe /S /C` on Windows.
+- The shell is `bash -c`, `C:\Windows\System32\cmd.exe /S /C` on Windows.
 
 ### Multi-stage builds
 

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -37,7 +37,7 @@ module Context = struct
 
   let v ?switch ?(env=[]) ?(user=Obuilder_spec.root) ?workdir ?shell ?(secrets=[]) ~log ~src_dir () =
     let workdir = Option.value ~default:(if Sys.win32 then {|C:/|} else "/") workdir in
-    let shell = Option.value ~default:(if Sys.win32 then ["cmd"; "/S"; "/C"] else ["/bin/bash"; "-c"]) shell in
+    let shell = Option.value ~default:(if Sys.win32 then ["cmd"; "/S"; "/C"] else ["/usr/bin/env"; "bash"; "-c"]) shell in
     { switch; env; src_dir; user; workdir; shell; log; scope = Scope.empty; secrets }
 
   let with_binding name value t =

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -16,7 +16,7 @@ module Context : sig
       @param env Environment in which to run commands.
       @param user Container user to run as.
       @param workdir Directory in the container namespace for cwd.
-      @param shell The command used to run shell commands (default [["/bin/bash"; "-c"]]).
+      @param shell The command used to run shell commands (default [["/usr/bin/env"; "bash"; "-c"]]).
       @param secrets Provided key-value pairs for secrets.
       @param log Function to receive log data.
   *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -48,7 +48,7 @@ let mock_op ?(result=Lwt_result.return ()) ?(delay_store=Lwt.return_unit) ?cance
   Mock_store.delay_store := delay_store;
   let cmd =
     match config.argv with
-    | ["/bin/bash"; "-c"; cmd] | ["cmd"; "/S"; "/C"; cmd] -> cmd
+    | ["/usr/bin/env" ; "bash"; "-c"; cmd] | ["cmd"; "/S"; "/C"; cmd] -> cmd
     | x -> Fmt.str "%a" Fmt.(Dump.list string) x
   in
   Build_log.printf log "%s@." cmd >>= fun () ->
@@ -715,7 +715,8 @@ let test_copy_bash _switch () =
         Os.pread ["cygpath"; "-m"; src_dir] >>= fun src_dir ->
         Lwt.return (String.trim bash, String.trim src_dir)
       else
-        Lwt.return ("/bin/bash", src_dir)
+        Os.pread ["which"; "bash"] >>= fun bash ->
+        Lwt.return (String.trim bash, src_dir)
     end >>= fun (bash, src_dir) ->
     let manifest_bash =
       Printf.sprintf "exec %s %S %S %d %s %d %s"


### PR DESCRIPTION
The default shell used to run obuilder commands is currently `/bin/bash`. While this works under Linux and MacOS, this will fail under *BSD where bash, once installed, will be `/usr/local/bin/bash`.

This PR tries to make the location of `bash` flexible:
- the test framework will use `which bash` to get its proper path.
- commands spawned as `/bin/bash -c ...` are replaced with `/usr/bin/env bash -c ...` which will perform identically as long as a `bash` binary exists in the user's `PATH`.

This PR is necessary for the `manifest.bash` test to pass under FreeBSD.