### PR TITLE
Allow Zfs.chown to use a symbolic user name

### DIFF
--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -93,8 +93,14 @@ let user = `Unix { Obuilder_spec.uid = Unix.getuid (); gid = Unix.getgid () }
 
 module Zfs = struct
   let chown ~user t ds =
-    let { Obuilder_spec.uid; gid } = match user with `Unix user -> user | `Windows _ -> assert false in
-    Os.sudo ["chown"; strf "%d:%d" uid gid; Dataset.path t ds]
+    let owner =
+      match user with
+      | `Unix user ->
+        let { Obuilder_spec.uid; gid } = user in strf "%d:%d" uid gid
+      | `Windows user ->
+        let { Obuilder_spec.name } = user in name
+    in
+    Os.sudo ["chown"; owner; Dataset.path t ds]
 
   let create t ds =
     Os.sudo ["zfs"; "create"; "--"; Dataset.full_name t ds]


### PR DESCRIPTION
The FreeBSD support for OBuilder allows jail sandboxes to be run by specifying the in-sandbox user by name, as done on Windows (i.e. `(user (name opam))` rather than `(user (uid 1000) (gid 1000))`. But doing this will sometimes trigger an `assert false` in `zfs_store` due to assumption that only uid/gid flavor can by used.

This PR trivially fixes this.