### PR TITLE
Adopt the OCaml Code of Conduct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Add a Docker backend for Windows and Linux jobs.
   (@MisterDA #127 #75, reviewed by @talex5, @tmcgilchrist)
+- Adopt the OCaml Code of Conduct (@rikusilvola)
 
 ### v0.5.1 2023-02-17
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Code of Conduct
+
+This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+# Enforcement
+
+This project follows the OCaml Code of Conduct [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).
+
+To report any violations, please contact:
+
+* Riku Silvola <riku [at] tarides [dot] com>
+* Tim McGilchrist <tim [at] tarides [dot] com>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,4 +9,4 @@ This project follows the OCaml Code of Conduct [enforcement policy](https://gith
 To report any violations, please contact:
 
 * Riku Silvola <riku [at] tarides [dot] com>
-* Tim McGilchrist <tim [at] tarides [dot] com>
+* Tim McGilchrist <timmcgil@gmail.com>


### PR DESCRIPTION
The OCaml Code of Conduct can be found in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed [in this Discourse thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

We propose adopting it for ocurrent/obuilder as well.