### PR TITLE
Raise and reraise exceptions with Stdlib rather than Lwt

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@
  (description
   "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment.")
  (depends
-  (lwt (>= 5.6.1))
+  (lwt (>= 5.7.0))
   astring
   (fmt (>= 0.8.9))
   logs

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.16)
 (name obuilder)
 
 (formatting disabled)
@@ -29,19 +29,19 @@
   astring
   (fmt (>= 0.8.9))
   logs
-  (cmdliner (>= 1.2.0))
-  (tar-unix (and (>= 2.4.0) (< 3.0.0)))
+  (cmdliner (>= 1.3.0))
+  (tar-unix (and (>= 2.6.0) (< 3.0.0)))
   (yojson (>= 1.6.0))
   sexplib
   ppx_deriving
   ppx_sexp_conv
   (sha (>= 1.15.4))
-  sqlite3
+  (sqlite3 (>= 5.2.0))
   (crunch (and (>= 3.3.1) :build))
   (obuilder-spec (= :version))
   fpath
-  (extunix (>= 0.4.0))
-  (ocaml (>= 4.14.1))
+  (extunix (>= 0.4.2))
+  (ocaml (>= 4.14.2))
   (alcotest-lwt (and (>= 1.7.0) :with-test))))
 
 (package
@@ -55,4 +55,4 @@
   astring
   ppx_deriving
   ppx_sexp_conv
-  (ocaml (>= 4.14.1))))
+  (ocaml (>= 4.14.2))))

--- a/example.spec
+++ b/example.spec
@@ -1,4 +1,4 @@
-; This script builds OBuilder itself using a snapshot of the ocaml/opam:debian-11-ocaml-4.14 base image.
+; This script builds OBuilder itself using a snapshot of the ocaml/opam:debian-12-ocaml-4.14 base image.
 ;
 ; Run it from the top-level of the OBuilder source tree, e.g.
 ;
@@ -7,11 +7,11 @@
 ; The result can then be found in /tank/HASH/rootfs/ (where HASH is displayed at the end of the build).
 
 ((build dev
-	((from ocaml/opam@sha256:4bfe3c0814b4220417d6ccbbed7eb5486a35d900024745c1f299973e9584e0e5)
+	((from ocaml/opam@sha256:02f01da51f1ed2ae4191f143a46a508e2a34652c11ad2715e2bbe8e0d36fc30d)
 	 (workdir /src)
 	 (user (uid 1000) (gid 1000))                           ; Build as the "opam" user
 	 (run (shell "sudo chown opam /src"))
-	 (env OPAM_HASH "f44d347b2119b4bdfddfb2a8ec55ae25c396c0d7")
+	 (env OPAM_HASH "8187cd8d3681d53f5042b5da316fa3f5e005a247")
 	 (run
 	  (network host)
 	  (shell "sudo apt-get --allow-releaseinfo-change update"))
@@ -42,7 +42,7 @@
 	  (exclude .git _build _opam))
 	 (run (shell "opam exec -- dune build @install @runtest"))))    ; Build and test
  ; Now generate a small runtime image with just the resulting binary:
- (from debian:11)
+ (from debian:12)
  (run
   (network host)
   (shell "apt-get update && apt-get install -y libsqlite3-0 --no-install-recommends"))

--- a/example.windows.spec
+++ b/example.windows.spec
@@ -1,5 +1,5 @@
 ; This script builds OBuilder itself using a snapshot of the
-; ocaml/opam:windows-mingw-ltsc2022-ocaml-4.14 base image.
+; ocaml/opam:windows-server-mingw-ltsc2022-ocaml-4.14 base image.
 ;
 ; Run it from the top-level of the OBuilder source tree, e.g.
 ;
@@ -12,10 +12,10 @@
 ; ROOTID is computed as follows: $(realpath "$(root)" | sha256sum | cut -b -7)
 
 ((build dev
-	((from ocaml/opam@sha256:4bfe3c0814b4220417d6ccbbed7eb5486a35d900024745c1f299973e9584e0e5)
+	((from ocaml/opam@sha256:cdd6e6604489d7700af2768f939439593c5c2f5e6585db8827297ec02d1113ef)
 	 (workdir /src)
 	 (env OPAM_REPO_MINGW_HASH "921b0eceb594f96c0c7f40bb2676783be4362aeb") ; Fix the version of opam-repository-mingw we want
-	 (env OPAM_HASH "f44d347b2119b4bdfddfb2a8ec55ae25c396c0d7") ; Fix the version of opam-repository we want
+	 (env OPAM_HASH "8187cd8d3681d53f5042b5da316fa3f5e005a247") ; Fix the version of opam-repository we want
 	 (shell /cygwin64/bin/bash.exe --login -c)
 	 (run
 	  (network "nat")
@@ -73,7 +73,7 @@
 	  (exclude .git _build _opam duniverse))
 	 (run (shell "ocaml-env exec --64 -- dune build @install"))))    ; Build
  ; Now generate a small runtime image with just the resulting binary:
- (from mcr.microsoft.com/windows/servercore:ltsc2022)
+ (from mcr.microsoft.com/windows/server:ltsc2022)
  (run (shell "mkdir C:\obuilder"))
  (copy (from (build dev))
        (src /cygwin64/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libsqlite3-0.dll)

--- a/lib/archive_extract.ml
+++ b/lib/archive_extract.ml
@@ -24,5 +24,4 @@ let fetch ~log ~rootfs base =
     (function
      | Sys_error s ->
        Fmt.failwith "Archive fetcher encountered a system error: %s" s
-     | e -> Lwt.fail e)
-
+     | ex -> Lwt.reraise ex)

--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -154,7 +154,7 @@ let build t ?base ~id fn =
   (fun ex ->
       Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
       Btrfs.subvolume_delete result_tmp >>= fun () ->
-      Lwt.fail ex
+      Lwt.reraise ex
   )
 
 let result t id =

--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -90,11 +90,8 @@ let check_kernel_version () =
       | Some maj, Some min when (maj, min) >= (5, 8) ->
           Lwt.return_unit
       | Some maj, Some min ->
-          Lwt.fail_with
-            (Fmt.str
-               "You need at least linux 5.8 to use the btrfs backend, \
-                but current kernel version is '%d.%d'"
-               maj min)
+          Fmt.failwith "You need at least linux 5.8 to use the btrfs backend, \
+                        but current kernel version is '%d.%d'" maj min
       | _, _ ->
           Fmt.failwith "Could not parse kernel version %S" kver
       end

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -22,7 +22,7 @@ let catch_cancel fn =
   Lwt.catch fn
     (function
       | Lwt.Canceled -> Lwt_result.fail `Cancelled
-      | ex -> Lwt.fail ex
+      | ex -> Lwt.reraise ex
     )
 
 let tail ?switch t dst =

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -238,7 +238,7 @@ let win32_unlink fn =
   Lwt.catch
     (fun () -> Lwt_unix.unlink fn)
     (function
-      | Unix.Unix_error (Unix.EACCES, _, _) as exn ->
+      | Unix.Unix_error (Unix.EACCES, _, _) as ex ->
         Lwt_unix.lstat fn >>= fun {st_perm; _} ->
         (* Try removing the read-only attribute *)
         Lwt_unix.chmod fn 0o666 >>= fun () ->
@@ -247,8 +247,8 @@ let win32_unlink fn =
           (function _ ->
              (* Restore original permissions *)
              Lwt_unix.chmod fn st_perm >>= fun () ->
-             Lwt.fail exn)
-      | exn -> Lwt.fail exn)
+             Lwt.reraise ex)
+      | ex -> Lwt.reraise ex)
 
 let unlink =
   if Sys.win32 then

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -105,8 +105,8 @@ let exec ?timeout ?cwd ?stdin ?stdout ?stderr ?(is_success=((=) 0)) ?(cmd="") ar
   let pp f = pp_cmd f (cmd, argv) in
   !lwt_process_exec ?timeout ?cwd ?stdin ?stdout ?stderr ~pp (cmd, Array.of_list argv) >>= function
   | Ok n when is_success n -> Lwt.return_unit
-  | Ok n -> Lwt.fail_with (Fmt.str "%t failed with exit status %d" pp n)
-  | Error (`Msg m) -> Lwt.fail (Failure m)
+  | Ok n -> Fmt.failwith "%t failed with exit status %d" pp n
+  | Error (`Msg m) -> failwith m
 
 let running_as_root = not (Sys.unix) || Unix.getuid () = 0
 
@@ -205,7 +205,7 @@ let pread_all ?stdin ~pp ?(cmd="") argv =
   >>= fun (stdin, stdout) ->
   child >>= function
   | Ok i -> Lwt.return (i, stdin, stdout)
-  | Error (`Msg m) -> Lwt.fail (Failure m)
+  | Error (`Msg m) -> failwith m
 
 let check_dir x =
   match Unix.lstat x with
@@ -300,4 +300,3 @@ let read_lines name process =
     | Some s -> loop ((process s) :: acc)
     | None -> close_in ic; acc in
   loop []
-

--- a/lib/overlayfs_store.ml
+++ b/lib/overlayfs_store.ml
@@ -202,7 +202,8 @@ let build t ?base ~id fn =
       >>= fun () -> Lwt.return r)
     (fun ex ->
       Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
-      Overlayfs.delete [ merged; work; in_progress ] >>= fun () -> Lwt.fail ex)
+      Overlayfs.delete [ merged; work; in_progress ] >>= fun () ->
+      Lwt.reraise ex)
 
 let delete t id =
   let path = Path.result t id in
@@ -218,7 +219,7 @@ let delete t id =
       |> List.map decendants
       |> List.flatten
       |> List.append [ parent ]
-  in decendants path 
+  in decendants path
       |> Overlayfs.delete
 
 let result t id =

--- a/lib/rsync_store.ml
+++ b/lib/rsync_store.ml
@@ -110,7 +110,7 @@ let build t ?base ~id fn =
     (fun ex ->
       Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
       Rsync.delete result_tmp >>= fun () ->
-      Lwt.fail ex
+      Lwt.reraise ex
     )
 
 let delete t id =

--- a/lib/xfs_store.ml
+++ b/lib/xfs_store.ml
@@ -78,7 +78,7 @@ let build t ?base ~id fn =
     (fun ex ->
       Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
       Xfs.delete result_tmp >>= fun () ->
-      Lwt.fail ex
+      Lwt.reraise ex
     )
 
 let delete t id =
@@ -136,7 +136,7 @@ let cache ~user t name =
         cache.gen <- cache.gen + 1;
         Xfs.delete snapshot >>= fun () ->
         Xfs.rename ~src:tmp ~dst:snapshot
-      ) else 
+      ) else
         Xfs.delete tmp
     end
   in

--- a/lib/zfs_store.ml
+++ b/lib/zfs_store.ml
@@ -247,7 +247,7 @@ let build t ?base ~id fn =
     (fun ex ->
         Log.warn (fun f -> f "Uncaught exception from %S build function: %a" id Fmt.exn ex);
         Zfs.destroy t ds `And_snapshots >>= fun () ->
-        Lwt.fail ex
+        Lwt.reraise ex
     )
 
 let result t id =

--- a/obuilder-spec.opam
+++ b/obuilder-spec.opam
@@ -24,13 +24,13 @@ homepage: "https://github.com/ocurrent/obuilder"
 doc: "https://ocurrent.github.io/obuilder/"
 bug-reports: "https://github.com/ocurrent/obuilder/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.16"}
   "fmt" {>= "0.8.9"}
   "sexplib"
   "astring"
   "ppx_deriving"
   "ppx_sexp_conv"
-  "ocaml" {>= "4.14.1"}
+  "ocaml" {>= "4.14.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/obuilder.opam
+++ b/obuilder.opam
@@ -24,24 +24,24 @@ homepage: "https://github.com/ocurrent/obuilder"
 doc: "https://ocurrent.github.io/obuilder/"
 bug-reports: "https://github.com/ocurrent/obuilder/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.16"}
   "lwt" {>= "5.6.1"}
   "astring"
   "fmt" {>= "0.8.9"}
   "logs"
-  "cmdliner" {>= "1.2.0"}
-  "tar-unix" {>= "2.4.0" & < "3.0.0"}
+  "cmdliner" {>= "1.3.0"}
+  "tar-unix" {>= "2.6.0" & < "3.0.0"}
   "yojson" {>= "1.6.0"}
   "sexplib"
   "ppx_deriving"
   "ppx_sexp_conv"
   "sha" {>= "1.15.4"}
-  "sqlite3"
+  "sqlite3" {>= "5.2.0"}
   "crunch" {>= "3.3.1" & build}
   "obuilder-spec" {= version}
   "fpath"
-  "extunix" {>= "0.4.0"}
-  "ocaml" {>= "4.14.1"}
+  "extunix" {>= "0.4.2"}
+  "ocaml" {>= "4.14.2"}
   "alcotest-lwt" {>= "1.7.0" & with-test}
   "odoc" {with-doc}
 ]

--- a/obuilder.opam
+++ b/obuilder.opam
@@ -25,7 +25,7 @@ doc: "https://ocurrent.github.io/obuilder/"
 bug-reports: "https://github.com/ocurrent/obuilder/issues"
 depends: [
   "dune" {>= "3.16"}
-  "lwt" {>= "5.6.1"}
+  "lwt" {>= "5.7.0"}
   "astring"
   "fmt" {>= "0.8.9"}
   "logs"


### PR DESCRIPTION
Lwt's documentation reads:

> In most cases, it is better to use `failwith s` from the standard
> library.

and

> Whenever possible, it is recommended to use `raise exn` instead, as
> raise captures a backtrace, while `Lwt.fail` does not. If you call
> `raise exn` in a callback that is expected by Lwt to return a
> promise, Lwt will automatically wrap `exn` in a rejected promise,
> but the backtrace will have been recorded by the OCaml runtime.
>
> For example, `bind`'s second argument is a callback which returns a
> promise. And so it is recommended to use `raise` in the body of that
> callback.
>
> Use `Lwt.fail` only when you specifically want to create a rejected
> promise, to pass to another function, or store in a data structure.

Prefer to capture backtraces to improve debugability.

See also https://github.com/ocsigen/lwt/pull/1008.