### PR TITLE
Retry unmount on macOS

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -204,7 +204,7 @@ module Make (Raw_store : S.STORE) (Sandbox : S.SANDBOX) (Fetch : S.FETCHER) = st
       (resolved_secret :: result) ) (Ok []) secrets
 
   let rec run_steps t ~(context:Context.t) ~base = function
-    | [] -> Sandbox.finished () >>= fun () -> Lwt_result.return base
+    | [] -> Sandbox.finished t.sandbox >>= fun () -> Lwt_result.return base
     | op :: ops ->
       context.log `Heading Fmt.(str "%a" (pp_op ~context) op);
       let k = run_steps t ops in

--- a/lib/docker_sandbox.ml
+++ b/lib/docker_sandbox.ml
@@ -459,7 +459,7 @@ let create (c : config) =
   let+ () = if Result.is_error volume_exists then create_tar_volume t else Lwt.return_unit in
   t
 
-let finished () =
+let finished _ =
   Lwt.return ()
 
 open Cmdliner

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -89,7 +89,7 @@ module type SANDBOX = sig
       @param log Used for child's stdout and stderr.
   *)
 
-  val finished : unit -> unit Lwt.t
+  val finished : t -> unit Lwt.t
 end
 
 module type BUILDER = sig

--- a/lib/sandbox.jail.ml
+++ b/lib/sandbox.jail.ml
@@ -165,7 +165,7 @@ let create ~state_dir:_ _c =
     jail_name_prefix = "obuilder_" ^ (Int.to_string (Unix.getpid ()));
   }
 
-let finished () =
+let finished _ =
   Lwt.return ()
 
 open Cmdliner

--- a/lib/sandbox.macos.ml
+++ b/lib/sandbox.macos.ml
@@ -109,8 +109,8 @@ let create ~state_dir:_ c =
     lock = Lwt_mutex.create ();
   }
 
-let finished () =
-  Os.sudo [ "zfs"; "unmount"; "obuilder/result" ] >>= fun () ->
+let finished (t : t) =
+  Macos.sudo_fallback [ "zfs"; "unmount"; "obuilder/result" ] [ "zfs"; "unmount"; "-f"; "obuilder/result" ] ~uid:t.uid >>= fun () ->
   Os.sudo [ "zfs"; "mount"; "obuilder/result" ] >>= fun () ->
   Lwt.return ()
 

--- a/lib/sandbox.mli
+++ b/lib/sandbox.mli
@@ -13,6 +13,6 @@ val create : state_dir:string -> config -> t Lwt.t
 (** [create ~state_dir config] is a sandboxing system that keeps state in [state_dir]
     and is configured using [config]. *)
 
-val finished : unit -> unit Lwt.t
+val finished : t -> unit Lwt.t
 (** [finished] is a call back to the sandbox which is triggered when the current job
     is finished. The sandbox may choose do nothing. *)

--- a/lib/sandbox.runc.ml
+++ b/lib/sandbox.runc.ml
@@ -333,7 +333,7 @@ let create ~state_dir (c : config) =
   clean_runc state_dir >|= fun () ->
   { runc_state_dir = state_dir; fast_sync = c.fast_sync; arches }
 
-let finished () =
+let finished _ =
   Lwt.return ()
 
 open Cmdliner

--- a/test/mock_sandbox.ml
+++ b/test/mock_sandbox.ml
@@ -23,4 +23,4 @@ let run ~cancelled ?stdin ~log t (config:Obuilder.Config.t) dir =
 
 let create () = { expect = Queue.create () }
 
-let finished () = Lwt.return ()
+let finished _ = Lwt.return ()

--- a/test/mock_sandbox.mli
+++ b/test/mock_sandbox.mli
@@ -9,4 +9,4 @@ val expect :
         string ->
         (unit, [`Msg of string | `Cancelled]) Lwt_result.t) ->
   unit
-val finished : unit -> unit Lwt.t
+val finished : t -> unit Lwt.t


### PR DESCRIPTION
This may look like a lot of changes, but really, it's just a single line. The new behaviour will now retry the unmount on failure with the addition of the `-f` flag.

```
Os.sudo [ "zfs"; "unmount"; "obuilder/result" ]
```

to

```
Macos.sudo_fallback [ "zfs"; "unmount"; "obuilder/result" ] [ "zfs"; "unmount"; "-f"; "obuilder/result" ] ~uid:t.uid
```

Addresses https://github.com/ocurrent/ocaml-ci/issues/975