### PR TITLE
Fix pin on Windows

### DIFF
--- a/qemu/autounattend.xml.m4
+++ b/qemu/autounattend.xml.m4
@@ -248,7 +248,7 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>20</Order>
-                    <CommandLine>netsh advfirewall firewall set rule group="OpenSSH SSH Server Preview (sshd)" new profile=any enable=yes</CommandLine>
+                    <CommandLine>netsh advfirewall firewall set rule name="OpenSSH SSH Server Preview (sshd)" new profile=any enable=yes</CommandLine>
                     <Description>Configure OpenSSH</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">


### PR DESCRIPTION
Under Windows, we map access to download caches through NTFS junction points.  This effectively creates a file system directory which links to the cache drive.  However, we did not remove the junction points when the cache is not present.  During an `opam pin`, opam tries to create a folder under the `download-cache/git` directory (with no cache present).  The junction refers to a location which doesn't exist at this time and therefore the opam command fails.  This PR removes the junction when the cache is removed.