### PR TITLE
Fix ENOENT on shared build steps from stale build-log path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### Unreleased
+
+Build, store and runtime fixes:
+
+- Fix intermittent `ENOENT` build failures on shared steps: a finished build
+  log is now read via a retained file descriptor rather than reopening it at
+  its pre-rename path, which a late-joining log tailer could no longer find
+  once the store had renamed the build directory into place (@mtelvers)
+
 ### v0.7.0 2026-05-12
 
 New backends:

--- a/lib/build_log.ml
+++ b/lib/build_log.ml
@@ -5,7 +5,10 @@ let max_chunk_size = 4096
 type t = {
   mutable state : [
     | `Open of Lwt_unix.file_descr * unit Lwt_condition.t  (* Fires after writing more data. *)
-    | `Readonly of string
+    | `Readonly of [ `Path of string | `Fd of Lwt_unix.file_descr ]
+      (* A finished log: read via a held fd, which survives the store
+         renaming the build directory, or by reopening [path] (logs loaded
+         from disk, and Windows where the fd must close before the rename). *)
     | `Empty
     | `Finished
   ];
@@ -57,7 +60,12 @@ let tail ?switch t dst =
 
   match t.state with
   | `Finished -> invalid_arg "tail: log is finished!"
-  | `Readonly path ->
+  | `Readonly (`Fd fd) ->
+    with_dup fd @@ fun fd ->
+    let buf = Bytes.create max_chunk_size in
+    let cond = Lwt_condition.create () in
+    interrupt (open_tail fd cond buf 0)
+  | `Readonly (`Path path) ->
     let flags = [Unix.O_RDONLY; Unix.O_NONBLOCK; Unix.O_CLOEXEC] in
     Lwt_io.(with_file ~mode:input ~flags) path @@ fun ch ->
     let buf = Bytes.create max_chunk_size in
@@ -82,15 +90,21 @@ let finish t =
   match t.state with
   | `Finished -> Lwt.return_unit
   | `Open (fd, cond) ->
-    (* Close the fd (needed on Windows before the directory can be renamed)
-       but transition to Readonly so late-joining tailers can still read
-       the log file by path. *)
+    (* Close the write fd (required on Windows before the rename). Off
+       Windows, keep a read-only dup so late-joining tailers read via the fd
+       rather than the soon-to-be-renamed [path]; the second [finish] closes
+       it. *)
     (match t.path with
-     | Some path -> t.state <- `Readonly path
+     | Some _ when not Sys.win32 ->
+       t.state <- `Readonly (`Fd (Lwt_unix.dup ~cloexec:true fd))
+     | Some path -> t.state <- `Readonly (`Path path)
      | None -> t.state <- `Finished);
     Lwt_unix.close fd >|= fun () ->
     Lwt_condition.broadcast cond ()
-  | `Readonly _ ->
+  | `Readonly (`Fd fd) ->
+    t.state <- `Finished;
+    Lwt_unix.close fd
+  | `Readonly (`Path _) ->
     t.state <- `Finished;
     Lwt.return_unit
   | `Empty ->
@@ -110,7 +124,7 @@ let write t data =
 let of_saved path =
   Lwt_unix.lstat path >|= fun stat ->
   {
-    state = `Readonly path;
+    state = `Readonly (`Path path);
     len = stat.st_size;
     path = Some path;
   }

--- a/test/test.ml
+++ b/test/test.ml
@@ -821,6 +821,43 @@ let test_pread_nul _switch () =
   Os.pread ~stderr:`Dev_null args >|= fun actual ->
   Alcotest.(check string) "stdout" actual expected
 
+(* Regression test for a stale-path race in [Build_log].
+   The snapshot stores create the log under an [in-progress] directory and,
+   once the step succeeds, rename that directory to its [result] location.
+   A log left in the [`Readonly] state must therefore not be tied to the
+   original [in-progress] path: a late-joining tailer (e.g. a sibling build
+   sharing a deduplicated step) reads the log only after [finish], by which
+   point the directory may already have been renamed. Reopening by the old
+   path raised [ENOENT, "open", ".../in-progress/<id>/log"]; the log must
+   instead be read via a descriptor that follows the file through the
+   rename. (Not applicable on Windows, where the fd must be closed before
+   the rename and the path is used.) *)
+let test_log_survives_rename _switch () =
+  if Sys.win32 then Alcotest.skip ();
+  let tmp = Filename.get_temp_dir_name () / sprintf "obuilder-logtest-%d" (Unix.getpid ()) in
+  let in_progress = tmp / "in-progress" in
+  let result = tmp / "result" in
+  Os.ensure_dir tmp;
+  Os.ensure_dir in_progress;
+  let contents = "line one\nline two\n" in
+  Build_log.create (in_progress / "log") >>= fun log ->
+  Build_log.write log contents >>= fun () ->
+  (* Mimic the store: finish the log, then rename the build directory into
+     place so the original [in-progress] path no longer exists. *)
+  Build_log.finish log >>= fun () ->
+  Unix.rename in_progress result;
+  let buf = Buffer.create 64 in
+  Build_log.tail log (Buffer.add_string buf) >>= fun tail_result ->
+  Build_log.finish log >>= fun () ->     (* release the held descriptor *)
+  (try Sys.remove (result / "log") with _ -> ());
+  (try Unix.rmdir result with _ -> ());
+  (try Unix.rmdir tmp with _ -> ());
+  (match tail_result with
+   | Ok () -> ()
+   | Error `Cancelled -> Alcotest.fail "tail was cancelled");
+  Alcotest.(check string) "log readable after rename" contents (Buffer.contents buf);
+  Lwt.return_unit
+
 let () =
   let open Alcotest_lwt in
   let test_case name speed f =
@@ -879,6 +916,9 @@ let () =
       "process", [
         test_case "Execute a process" `Quick test_exec_nul;
         test_case "Read stdout of a process" `Quick test_pread_nul;
+      ];
+      "build_log", [
+        test_case "Readable after rename" `Quick test_log_survives_rename;
       ];
     ] @ needs_docker)
   end


### PR DESCRIPTION
We have been seeing intermittent build failures on busy workers:

```
Build failed: Unix.Unix_error(Unix.ENOENT, "open", "/var/cache/obuilder/in-progress/<id>/log")
Job failed: Internal error
```

When a build finishes, `Build_log.finish` parks the log as `` `Readonly <path> `` so late-joining tailers can still read it, but `<path>` is the in-progress location, and the store renames the build directory `in-progress -> result` on success. A late-joining tailer is typically a sibling job sharing a build step, via `db_store`'s `Some existing` branch), that reopens that path after the rename gets `ENOENT`.

Tailers that attach while the log is still `` `Open `` are fine as they `dup` the live fd, which follows the inode through the rename. Only the reopen-by-path in the finished state is affected. This bug was introduced by me in 393a5ef as part of the Windows HCS work as that required `finish` to close the fd before the rename (required on Windows) and reopen by path instead of relying on the still-open fd.

The fix is to keep a read-only `dup` of the fd and read tailers from it rather than reopening by path. The fd follows the file through the directory rename. On Windows the fd must be closed before the directory can be renamed, so it keeps reopening by path there.

Furthermore, this adds a regression test (`build_log` / "Readable after rename") that finishes a log, renames its directory as the store does, then tails it and asserts the content is still readable. It reproduces the exact `ENOENT` on the pre-fix code and passes with the fix.
