### PR TITLE
hcs: remove containers and reclaim snapshots so cancelled builds don't wedge the worker

### DIFF
--- a/lib/hcs_sandbox.ml
+++ b/lib/hcs_sandbox.ml
@@ -143,6 +143,16 @@ let run ~cancelled ?stdin:stdin ~log (t : t) config results_dir =
   if Lwt.is_sleeping cancelled then Lwt.return (r :> (unit, [`Msg of string | `Cancelled]) result)
   else Lwt_result.fail `Cancelled
   ) (fun () ->
+    (* [ctr run --rm] only removes the container when the run client observes a
+       clean task exit. On cancellation/timeout the task is killed and the
+       container is left behind, pinning its rootfs snapshot (which then leaks
+       and eventually blocks pruning). Remove it explicitly here so the snapshot
+       can be freed. Both commands are idempotent; a "not found" is expected on
+       the success path (where --rm already cleaned up) and is ignored. *)
+    (let pp f = Fmt.pf f "ctr task delete %S" container_id in
+     Os.exec_result [t.ctr_path; "task"; "delete"; "--force"; container_id] ~pp >>= fun _ -> Lwt.return_unit) >>= fun () ->
+    (let pp f = Fmt.pf f "ctr container rm %S" container_id in
+     Os.exec_result [t.ctr_path; "container"; "rm"; container_id] ~pp >>= fun _ -> Lwt.return_unit) >>= fun () ->
     (* Clean up HCN namespace if we created one *)
     match network_namespace with
     | Some ns ->

--- a/lib/hcs_store.ml
+++ b/lib/hcs_store.ml
@@ -106,6 +106,45 @@ let root t = t.root
 
 let df t = Lwt.return (Os.free_space_percent t.root)
 
+(* Recover from builds left running by a crash/reboot. containerd keeps the
+   [obuilder-run-*] containers alive across a worker restart, and they pin the
+   rootfs snapshot of each interrupted build. So, in order:
+   1. remove the left-over containers — this unpins the snapshots;
+   2. for each in-progress (result-tmp) build, remove the specific snapshot
+      named in its layerinfo and drop the entry. As the containers are already
+      gone the removal succeeds in a single pass.
+   Normal cancellations don't reach here: the sandbox tears the container down
+   per-run and the build error handler removes the snapshot on the spot. *)
+let clean_containers () =
+  Ctr.ctr_pread ["container"; "ls"; "-q"] >>= function
+  | Error _ -> Lwt.return_unit
+  | Ok output ->
+    String.split_on_char '\n' output
+    |> List.map String.trim
+    |> List.filter (Astring.String.is_prefix ~affix:"obuilder-run-")
+    |> Lwt_list.iter_s (fun id ->
+        Log.warn (fun f -> f "Removing left-over container %s" id);
+        (Ctr.ctr ["task"; "delete"; "--force"; id] >>= fun _ -> Lwt.return_unit) >>= fun () ->
+        Ctr.ctr ["container"; "rm"; id] >>= fun _ -> Lwt.return_unit)
+
+let clean_result_tmp root =
+  let dir = root / "result-tmp" in
+  Sys.readdir dir |> Array.to_list |> Lwt_list.iter_s (fun id ->
+      let path = dir / id in
+      let key =
+        let rootfs = path / "rootfs" in
+        if Sys.file_exists (Hcs.layerinfo_path rootfs) then Some (Hcs.read_layerinfo rootfs).snapshot_key
+        else if Sys.file_exists (Hcs.layerinfo_path path) then Some (Hcs.read_layerinfo path).snapshot_key
+        else None
+      in
+      (match key with
+       | Some key ->
+         Log.warn (fun f -> f "Removing snapshot %s of interrupted build %s" key id);
+         (Ctr.snapshot_rm ~key () >>= fun _ -> Lwt.return_unit) >>= fun () ->
+         (Ctr.snapshot_rm ~key:(key ^ "-committed") () >>= fun _ -> Lwt.return_unit)
+       | None -> Lwt.return_unit) >>= fun () ->
+      Os.rm ~directory:path)
+
 let create ~root =
   Os.ensure_dir root;
   Os.ensure_dir (root / "result");
@@ -113,7 +152,8 @@ let create ~root =
   Os.ensure_dir (root / "state");
   Os.ensure_dir (root / "cache");
   Os.ensure_dir (root / "cache-tmp");
-  purge (root / "result-tmp") >>= fun () ->
+  clean_containers () >>= fun () ->
+  clean_result_tmp root >>= fun () ->
   purge (root / "cache-tmp") >>= fun () ->
   Lwt.return { root; caches = Hashtbl.create 10; next = 0 }
 


### PR DESCRIPTION
The Windows (HCS) workers in our `windows-x86_64` pool repeatedly fell off the cluster: the `ocluster-worker` service stayed `RUNNING` but the scheduler showed it disconnected and no builds progressed. The worker log showed it spinning in a prune loop, removing nothing:

```
OBuilder partition: 28% free, 0 items
Pruning 100 items
Exec "ctr" "snapshot" "rm" "obuilder-base-...-committed"
Pruned 0 items
```

containerd had hundreds of `obuilder-*` snapshots while OBuilder's database had zero entries — the two had drifted completely apart, and the only snapshots prune tried to remove were the base layers, which can't be removed while children exist.

`Hcs_sandbox.run` runs each build step with `ctr run --rm` and, on cancellation, sends `ctr task kill -s SIGKILL`. But `--rm` only deletes the container when the run client observes a *clean* task exit. When the task is killed — which is exactly what every cancellation or timeout does — the container is **not** removed. It lingers and keeps its rootfs snapshot pinned.

From there it cascades:

1. A cancelled/timed-out build leaves an orphaned `obuilder-run-*` container pinning its snapshot.
2. OBuilder tries to delete that snapshot, fails (the container still holds it), but the delete is recorded as success (`val delete : t -> id -> unit Lwt.t` can't report failure), so the DB row is dropped while the snapshot survives.
3. The orphan then pins its parent, whose delete also fails, and the DB empties one cascade at a time.
4. With an empty DB the LRU pruner has nothing to evict, so completed layers accumulate until free space drops below the threshold and the worker wedges in a no-progress prune loop.

Cancellations are the common case (hundreds per worker over a week), so this builds up quickly. We confirmed `--rm`'s behaviour directly: start a container with `ctr run --rm`, `ctr task kill -s SIGKILL` it, and the container remains in `ctr container ls` — only an explicit `ctr task delete` + `ctr container rm` removes it.

Stop relying on `--rm` and manage the container lifecycle explicitly:

- **`Hcs_sandbox.run`** — in the `finalize` (so it runs on success, error and cancellation) issue `ctr task delete --force` + `ctr container rm`. The container is then actually gone, and OBuilder's existing build-error handler removes its snapshot.
- **`Hcs_store.create`** — recover crash/reboot leftovers at start-up (when `finalize` never ran): remove any leftover `obuilder-run-*` containers (which unpins their snapshots), then, for each interrupted build still in `result-tmp`, remove the specific snapshot named in its layer info. Containers first, snapshots second, in one pass.

No change to the `delete` signature or to `complete_deletes` — once the leak is closed the database stays in sync and normal leaf-first LRU pruning reclaims layers as before.