### PR TITLE
qemu: sync the guest filesystem before powering off

### DIFF
--- a/lib/qemu_sandbox.ml
+++ b/lib/qemu_sandbox.ml
@@ -136,6 +136,16 @@ let run ~cancelled ?stdin ~log t config result_tmp =
       Os.exec (ssh @ ["cmd"; "/c"; "rmdir '" ^ dst ^ "'"])
   ) config.Config.mounts >>= fun () ->
 
+  (* Flush the guest filesystem before powering off, so a hard [quit] (if the
+     guest does not power off within [qemu_boot_time]) cannot lose unsynced
+     data. Best-effort; Windows has no [sync]. *)
+  (match t.qemu_guest_os with
+    | Linux | OpenBSD ->
+      (Os.exec_result ~pp (ssh @ ["sync"]) >>= function
+        | Ok () -> Lwt.return_unit
+        | Error (`Msg m) -> Log.warn (fun f -> f "Pre-shutdown sync failed: %s" m); Lwt.return_unit)
+    | Windows -> Lwt.return_unit) >>= fun () ->
+
   (match t.qemu_guest_arch with
     | Amd64 ->
       Log.info (fun f -> f "Sending QEMU an ACPI shutdown event");


### PR DESCRIPTION
A `copy` step extracts a tar into the guest with `tar`/`gtar`, leaving the files in the guest's page cache. The qemu backend then powers the VM off with an ACPI `system_powerdown`, falling back to a hard `quit` if the guest hasn't stopped within `--qemu-boot-time`. Nothing flushes the guest filesystem first.

The OpenBSD images mount the root FS with soft-updates, so after a hard `quit` the file metadata survives but the unwritten data does not — the file keeps its name and size but is full of stale blocks. This showed up as opam parse errors on the `openbsd-78` runners (ocurrent/ocaml-ci#1061): the copied `.opam` files had the right sizes but contained other packages' opam files or directory blocks. It's intermittent because it only bites when the shutdown is slow enough to be interrupted by the hard `quit`.

This runs `sync` over SSH after the step's command and before powering off, so the data is on disk however the VM is then stopped. It's gated on `guest_os` (Windows has no `sync`), and a failed `sync` is logged but not fatal.