### PR TITLE
qemu: extract `copy` as root so it works on the OpenBSD worker

### DIFF
--- a/lib/qemu_sandbox.ml
+++ b/lib/qemu_sandbox.ml
@@ -169,7 +169,14 @@ let shell _ = []
 let tar t =
   match t.qemu_guest_os with
   | Linux -> tar t
-  | OpenBSD -> ["gtar"; "-xf"; "-"]
+  (* Extract as root via doas. obuilder's copy is designed to run as root
+     (Build sets the copy step's user to root), but the qemu backend always
+     connects as the unprivileged "opam" user. As opam, gtar exits with
+     failure (status 2) when it tries to restore the mtime/mode of a
+     pre-existing ancestor directory such as the root-owned /home. Running
+     under doas matches what the other backends do; the tar headers still
+     carry the target uid/gid, so the extracted files remain opam-owned. *)
+  | OpenBSD -> ["doas"; "gtar"; "-xf"; "-"]
   | Windows -> ["/cygdrive/c/Windows/System32/tar.exe"; "-xf"; "-"; "-C"; "/"]
 
 open Cmdliner


### PR DESCRIPTION
Build runs the `copy` step as root, and the runc, docker, hcs and jail backends all extract the copy tarball as root. The qemu backend is the exception: it always connects to the guest as the unprivileged `opam` user.

The copy tar stream includes a directory entry for each ancestor of the destination (`Tar_transfer` emits these for extractors that don't auto-create parents, e.g. Windows bsdtar). On extraction gtar restores each directory's mtime and mode; for a pre-existing, root-owned ancestor such as `/home` the `opam` user cannot, so gtar exits with failure status 2:

```
gtar: home: Cannot utime: Operation not permitted
gtar: Exiting with failure status due to previous errors
```

This was hit on the openbsd-amd64 worker after its build cache was rebuilt. It is not OpenBSD-version specific — 7.7 and 7.8 both ship GNU tar 1.35 and fail identically; the trigger is the ancestor directory entries, not the OS.

This extracts under `doas` on OpenBSD (the `opam` user is in `wheel`, nopass), matching the root extraction the other backends already use. The tar headers still carry the target uid/gid, so the extracted files remain `opam`-owned. (`--no-overwrite-dir` was tried first but only moves the failure from `utime` to `chmod`.) Linux qemu guests share the same design and could take the analogous `sudo tar`; left out here as it is untested.